### PR TITLE
refactor: use `Zstd` compression to save playerdata instead of storing it in JSON.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
             url = "https://oss.sonatype.org/content/repositories/snapshots/"
         }
     }
+
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
     }
@@ -29,24 +30,20 @@ minecraft {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-dependencies {
-    // you may put jars on which you depend on in ./libs
-    // or you may define them like so..
-    //compile "some.group:artifact:version:classifier"
-    //compile "some.group:artifact:version"
-      
-    // real examples
-    //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
-    //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
-
-    // for more info...
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
-
+configurations {
+    shade
+    compile.extendsFrom shade
 }
 
-processResources
-{
+repositories() {
+    mavenLocal()
+}
+
+dependencies {
+    shade "com.github.luben:zstd-jni:1.4.4-5"
+}
+
+processResources {
     // this will ensure that this task is redone when the versions change.
     inputs.property "version", project.version
     inputs.property "mcversion", project.minecraft.version
@@ -65,4 +62,10 @@ processResources
     }
 }
 
-sourceSets {main { output.resourcesDir = output.classesDir }}
+jar {
+    configurations.shade.each { dep ->
+        from(project.zipTree(dep)) {
+            exclude 'META-INF', 'META-INF/**'
+        }
+    }
+}

--- a/src/main/java/foxz/command/CmdAdapter.java
+++ b/src/main/java/foxz/command/CmdAdapter.java
@@ -1,0 +1,50 @@
+package foxz.command;
+
+import foxz.commandhelper.ChMcLogger;
+import foxz.commandhelper.annotations.Command;
+import foxz.commandhelper.annotations.SubCommand;
+import net.minecraft.nbt.NBTTagCompound;
+import noppes.npcs.controllers.PlayerDataController;
+import noppes.npcs.util.NBTJsonUtil;
+
+import java.io.File;
+import java.util.UUID;
+
+@Command(
+  name = "adapt",
+  desc = "Adapt all JSON data from one player to Zstd compress."
+)
+public class CmdAdapter extends ChMcLogger {
+
+    public CmdAdapter(Object sender) {
+        super(sender);
+    }
+
+    @SubCommand(
+      usage = "update all",
+      desc = "Update all JSON data from one player to Zstd compress.",
+      name = "update"
+    )
+    public boolean update(String[] args) {
+        File directory = PlayerDataController.instance.getSaveDir();
+
+        try {
+            for (String file : directory.list()) {
+                if (!file.endsWith(".json")) continue;
+
+                UUID uuid = UUID.fromString(
+                  file.replace(".json", "")
+                );
+                NBTTagCompound compound = NBTJsonUtil.LoadFile(
+                  new File(directory, file)
+                );
+
+                PlayerDataController.instance.savePlayerData(compound, uuid);
+            }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/foxz/command/CmdNoppes.java
+++ b/src/main/java/foxz/command/CmdNoppes.java
@@ -38,7 +38,7 @@ import foxz.utils.Utils;
 @Command(
         name = "noppes",
         desc = "noppes root command",
-        sub = {CmdClone.class, CmdScript.class, CmdQuest.class, CmdDialog.class, CmdConfig.class}
+        sub = {CmdClone.class, CmdScript.class, CmdQuest.class, CmdDialog.class, CmdConfig.class, CmdAdapter.class}
 )
 public class CmdNoppes extends ChMcLogger {
 

--- a/src/main/java/me/luizotavio/zstd/NBTReaderUtil.java
+++ b/src/main/java/me/luizotavio/zstd/NBTReaderUtil.java
@@ -1,0 +1,59 @@
+package me.luizotavio.zstd;
+
+import com.github.luben.zstd.Zstd;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTSizeTracker;
+import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+public class NBTReaderUtil {
+
+    /**
+     * Reads a block of zstd-compressed data. This method
+     * expects the following ints to be the compressed size,
+     * and uncompressed size respectively.
+     *
+     * @return the uncompressed data
+     * @throws IOException if the bytes cannot be read
+     * @throws IllegalArgumentException if the uncompressed length doesn't match
+     */
+
+    public static byte[] readCompressed(DataInput inputStream) throws IOException {
+        int compressedLength = inputStream.readInt();
+        int uncompressedLength = inputStream.readInt();
+
+        if (compressedLength < 0 || uncompressedLength < 0) {
+            throw new IllegalArgumentException("Invalid length");
+        }
+
+        byte[] compressed = new byte[compressedLength];
+
+        inputStream.readFully(compressed);
+
+        return Zstd.decompress(compressed, uncompressedLength);
+    }
+
+    /**
+     * Reads and parses a block of zstd-compressed bytes as
+     * an NBT named compound tag.
+     *
+     * @return the parsed named compound tag.
+     * @throws IOException if the bytes cannot be read
+     * @see .readCompressed
+     */
+    public static NBTTagCompound readCompressCompound(DataInput inputStream) throws IOException {
+        NBTTagCompound compound;
+
+        byte[] compressed = readCompressed(inputStream);
+
+        try (DataInputStream dataInputStream = new DataInputStream(new ByteArrayInputStream(compressed))) {
+            compound = CompressedStreamTools.func_152456_a(dataInputStream, NBTSizeTracker.field_152451_a);
+        }
+
+        return compound;
+    }
+}

--- a/src/main/java/me/luizotavio/zstd/NBTWriterUtil.java
+++ b/src/main/java/me/luizotavio/zstd/NBTWriterUtil.java
@@ -1,0 +1,21 @@
+package me.luizotavio.zstd;
+
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class NBTWriterUtil {
+
+    public static byte[] writeCompound(NBTTagCompound compound) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        try (DataOutputStream dataOutputStream = new DataOutputStream(outputStream)) {
+            CompressedStreamTools.write(compound, dataOutputStream);
+        }
+
+        return outputStream.toByteArray();
+    }
+}

--- a/src/main/java/noppes/npcs/NoppesUtilPlayer.java
+++ b/src/main/java/noppes/npcs/NoppesUtilPlayer.java
@@ -41,8 +41,10 @@ import noppes.npcs.controllers.QuestData;
 import noppes.npcs.controllers.TransportController;
 import noppes.npcs.controllers.TransportLocation;
 import noppes.npcs.entity.EntityNPCInterface;
+import noppes.npcs.event.PlayerCompleteQuestEvent;
 import noppes.npcs.roles.RoleFollower;
 import cpw.mods.fml.common.network.internal.FMLProxyPacket;
+import noppes.npcs.util.EventBus;
 
 public class NoppesUtilPlayer {
 
@@ -293,12 +295,22 @@ public class NoppesUtilPlayer {
 	public static void questCompletion(EntityPlayerMP player, int questId) {
 		PlayerQuestData playerdata = PlayerDataController.instance.getPlayerData(player).questData;
 		QuestData data = playerdata.activeQuests.get(questId);
-		if(data == null)
+
+		if(data == null) {
 			return;
+		}
 		
-		if(!data.quest.questInterface.isCompleted(player))
+		if(!data.quest.questInterface.isCompleted(player)) {
 			return;
-		
+		}
+
+		PlayerCompleteQuestEvent event = EventBus.callTo(
+				new PlayerCompleteQuestEvent(player, data.quest)
+		);
+
+		if(event.isCanceled()) {
+			return;
+		}
 
 		data.quest.questInterface.handleComplete(player);
 		if(data.quest.rewardExp > 0){

--- a/src/main/java/noppes/npcs/NoppesUtilServer.java
+++ b/src/main/java/noppes/npcs/NoppesUtilServer.java
@@ -356,7 +356,6 @@ public class NoppesUtilServer {
 		Map<String,Integer> map = new HashMap<String,Integer>();
         
 		if(type == EnumPlayerData.Players){
-	        File loc = PlayerDataController.instance.getSaveDir();
 	        for(String username : PlayerDataController.instance.getUsernameData().keySet()){
 	        	map.put(username, 0);
 	        }

--- a/src/main/java/noppes/npcs/ServerEventsHandler.java
+++ b/src/main/java/noppes/npcs/ServerEventsHandler.java
@@ -7,19 +7,18 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
+import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.MathHelper;
-import net.minecraft.util.StatCollector;
+import net.minecraft.util.*;
 import net.minecraft.village.MerchantRecipeList;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
@@ -35,323 +34,436 @@ import noppes.npcs.constants.EnumPacketClient;
 import noppes.npcs.constants.EnumQuestType;
 import noppes.npcs.constants.EnumRoleType;
 import noppes.npcs.constants.EnumScriptType;
-import noppes.npcs.controllers.Line;
-import noppes.npcs.controllers.PlayerData;
-import noppes.npcs.controllers.PlayerDataController;
-import noppes.npcs.controllers.PlayerQuestData;
-import noppes.npcs.controllers.QuestData;
-import noppes.npcs.controllers.RecipeCarpentry;
-import noppes.npcs.controllers.RecipeController;
-import noppes.npcs.controllers.ServerCloneController;
+import noppes.npcs.controllers.*;
 import noppes.npcs.entity.EntityNPCInterface;
+import noppes.npcs.event.FactionGainPointsEvent;
+import noppes.npcs.event.NPCDeathEvent;
+import noppes.npcs.event.NPCKillEntityEvent;
+import noppes.npcs.event.PlayerInteractAtNPCEvent;
 import noppes.npcs.items.ItemExcalibur;
 import noppes.npcs.items.ItemShield;
 import noppes.npcs.items.ItemSoulstoneEmpty;
 import noppes.npcs.quests.QuestKill;
 import noppes.npcs.roles.RoleFollower;
+import noppes.npcs.util.EventBus;
 
 public class ServerEventsHandler {
 
-	public static EntityVillager Merchant;
-	public static Entity mounted;
-	
-//	private HashMap<String, Integer> exps = new HashMap<String, Integer>();
+    private final MinecraftServer server = MinecraftServer.getServer();
+
+    public static EntityVillager Merchant;
+    public static Entity mounted;
+
+    @SubscribeEvent
+    public void invoke(EntityInteractEvent event) {
+        EntityPlayer player = event.entityPlayer;
+
+        ItemStack item = player.getCurrentEquippedItem();
+
+        if (item == null) {
+            return;
+        }
+
+        boolean isRemote = player.worldObj.isRemote,
+          isNPC = event.target instanceof EntityNPCInterface;
+
+        if (
+          !isRemote && CustomNpcs.OpsOnly &&
+            !server.getConfigurationManager().func_152596_g(player.getGameProfile())
+        ) {
+            return;
+        }
+
+        Item stack = item.getItem();
+
+        if (!isRemote && stack == CustomItems.soulstoneEmpty && event.target instanceof EntityLivingBase) {
+            ItemSoulstoneEmpty soulstoneEmpty = (ItemSoulstoneEmpty) stack;
+
+            soulstoneEmpty.store(
+              (EntityLivingBase) event.target,
+              item,
+              player
+            );
+        }
+
+        if (stack == CustomItems.wand && isNPC && !isRemote) {
+            EntityNPCInterface npc = (EntityNPCInterface) event.target;
+
+            PlayerInteractAtNPCEvent call = EventBus.callTo(
+              new PlayerInteractAtNPCEvent(
+                player,
+                npc
+              )
+            );
+
+            if (!call.isCanceled()) {
+                if (!CustomNpcsPermissions.hasPermission(player, CustomNpcsPermissions.NPC_GUI)) {
+                    return;
+                }
+
+                event.setCanceled(true);
+
+                NoppesUtilServer.sendOpenGui(player, EnumGuiType.MainMenuDisplay, npc);
+            }
+        }
+
+        if (stack == CustomItems.cloner && !isRemote && !(event.target instanceof EntityPlayer)) {
+            NBTTagCompound compound = new NBTTagCompound();
+
+            if (!event.target.writeToNBTOptional(compound)) {
+                return;
+            }
+
+            PlayerData data = PlayerDataController.instance.getPlayerData(player);
+            ServerCloneController.Instance.cleanTags(compound);
+
+            if (!Server.sendData((EntityPlayerMP) player, EnumPacketClient.CLONE, compound)) {
+                player.addChatMessage(new ChatComponentText("Entity too big to clone"));
+            }
+
+            data.cloned = compound;
+
+            event.setCanceled(true);
+        }
+
+        if (stack == CustomItems.scripter && !isRemote && isNPC) {
+            EntityNPCInterface npc = (EntityNPCInterface) event.target;
+
+            PlayerInteractAtNPCEvent call = EventBus.callTo(
+              new PlayerInteractAtNPCEvent(
+                player,
+                npc
+              )
+            );
+
+            boolean result = call.isCanceled();
+
+            event.setCanceled(
+              result
+            );
+
+            if (!result) {
+                if (!CustomNpcsPermissions.hasPermission(player, CustomNpcsPermissions.NPC_GUI)) {
+                    return;
+                }
+
+                NoppesUtilServer.setEditingNpc(player, npc);
+
+                Server.sendData((EntityPlayerMP) player, EnumPacketClient.GUI, EnumGuiType.Script.ordinal());
+            }
+        }
+
+        if (stack == CustomItems.mount) {
+            PlayerInteractAtNPCEvent npcEvent = EventBus.callTo(
+              new PlayerInteractAtNPCEvent(
+                player,
+                (EntityNPCInterface) event.target
+              )
+            );
+
+            if (!CustomNpcsPermissions.hasPermission(event.entityPlayer, CustomNpcsPermissions.TOOL_MOUNTER)) {
+                return;
+            }
+
+            event.setCanceled(true);
+
+            mounted = event.target;
+
+            if (isRemote) {
+                CustomNpcs.proxy.openGui(
+                  MathHelper.floor_double(mounted.posX),
+                  MathHelper.floor_double(mounted.posY),
+                  MathHelper.floor_double(mounted.posZ),
+                  EnumGuiType.MobSpawnerMounter,
+                  player);
+            }
+        }
+
+        if (stack == CustomItems.wand && event.target instanceof EntityVillager) {
+            if (!CustomNpcsPermissions.hasPermission(player, CustomNpcsPermissions.EDIT_VILLAGER)) {
+                return;
+            }
+
+            event.setCanceled(true);
+
+            Merchant = (EntityVillager) event.target;
+
+            if (!isRemote) {
+                player.openGui(
+                  CustomNpcs.instance,
+                  EnumGuiType.MerchantAdd.ordinal(),
+                  player.worldObj,
+                  0,
+                  0,
+                  0
+                );
+
+                MerchantRecipeList merchantrecipelist = Merchant.getRecipes(player);
+
+                if (merchantrecipelist != null) {
+                    Server.sendData(
+                      (EntityPlayerMP) player,
+                      EnumPacketClient.VILLAGER_LIST,
+                      merchantrecipelist
+                    );
+                }
+            }
+
+        }
+    }
+
+    @SubscribeEvent
+    public void invoke(LivingHurtEvent event) {
+        if (!(event.entityLiving instanceof EntityPlayer))
+            return;
+
+        EntityPlayer player = (EntityPlayer) event.entityLiving;
+        if (event.source.isUnblockable() || event.source.isFireDamage())
+            return;
+        if (!player.isBlocking())
+            return;
+        ItemStack item = player.getCurrentEquippedItem();
+        if (item == null || !(item.getItem() instanceof ItemShield))
+            return;
+        if (((ItemShield) item.getItem()).material.getDamageVsEntity() < player.getRNG().nextInt(9))
+            return;
+        float damage = item.getItemDamage() + event.ammount;
+
+        item.damageItem((int) event.ammount, player);
+
+        if (damage > item.getMaxDamage())
+            event.ammount = damage - item.getMaxDamage();
+        else {
+            event.ammount = 0;
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public void invoke(PlayerInteractEvent event) {
+        EntityPlayer player = event.entityPlayer;
+        Block block = player.worldObj.getBlock(event.x, event.y, event.z);
+        if (event.action == Action.LEFT_CLICK_BLOCK && player.getHeldItem() != null && player.getHeldItem().getItem() == CustomItems.teleporter) {
+            event.setCanceled(true);
+        }
+
+        if (block == Blocks.crafting_table && event.action == Action.RIGHT_CLICK_BLOCK && !player.worldObj.isRemote) {
+            RecipeController controller = RecipeController.instance;
+            NBTTagList list = new NBTTagList();
+            int i = 0;
+            for (RecipeCarpentry recipe : controller.globalRecipes.values()) {
+                list.appendTag(recipe.writeNBT());
+                i++;
+                if (i % 10 == 0) {
+                    NBTTagCompound compound = new NBTTagCompound();
+                    compound.setTag("recipes", list);
+                    Server.sendData((EntityPlayerMP) player, EnumPacketClient.SYNCRECIPES_ADD, compound);
+                    list = new NBTTagList();
+                }
+            }
+
+            if (i % 10 != 0) {
+                NBTTagCompound compound = new NBTTagCompound();
+                compound.setTag("recipes", list);
+                Server.sendData((EntityPlayerMP) player, EnumPacketClient.SYNCRECIPES_ADD, compound);
+            }
+            Server.sendData((EntityPlayerMP) player, EnumPacketClient.SYNCRECIPES_WORKBENCH);
+        }
+        if (block == CustomItems.carpentyBench && event.action == Action.RIGHT_CLICK_BLOCK && !player.worldObj.isRemote) {
+            RecipeController controller = RecipeController.instance;
+            NBTTagList list = new NBTTagList();
+            int i = 0;
+            for (RecipeCarpentry recipe : controller.anvilRecipes.values()) {
+                list.appendTag(recipe.writeNBT());
+                i++;
+                if (i % 10 == 0) {
+                    NBTTagCompound compound = new NBTTagCompound();
+                    compound.setTag("recipes", list);
+                    Server.sendData((EntityPlayerMP) player, EnumPacketClient.SYNCRECIPES_ADD, compound);
+                    list = new NBTTagList();
+                }
+            }
+
+            if (i % 10 != 0) {
+                NBTTagCompound compound = new NBTTagCompound();
+                compound.setTag("recipes", list);
+                Server.sendData((EntityPlayerMP) player, EnumPacketClient.SYNCRECIPES_ADD, compound);
+            }
+            Server.sendData((EntityPlayerMP) player, EnumPacketClient.SYNCRECIPES_CARPENTRYBENCH);
+        }
+        if ((block == CustomItems.banner || block == CustomItems.wallBanner || block == CustomItems.sign) && event.action == Action.RIGHT_CLICK_BLOCK) {
+            ItemStack item = player.inventory.getCurrentItem();
+            if (item == null || item.getItem() == null)
+                return;
+            int y = event.y;
+            int meta = player.worldObj.getBlockMetadata(event.x, event.y, event.z);
+            if (meta >= 7)
+                y--;
+            TileBanner tile = (TileBanner) player.worldObj.getTileEntity(event.x, y, event.z);
+            if (!tile.canEdit()) {
+                if (item.getItem() == CustomItems.wand && CustomNpcsPermissions.hasPermission(player, CustomNpcsPermissions.EDIT_BLOCKS)) {
+                    tile.time = System.currentTimeMillis();
+                    if (player.worldObj.isRemote)
+                        player.addChatComponentMessage(new ChatComponentTranslation("availability.editIcon"));
+                }
+                return;
+            }
+
+            if (!player.worldObj.isRemote) {
+                tile.icon = item.copy();
+                player.worldObj.markBlockForUpdate(event.x, y, event.z);
+                event.setCanceled(true);
+            }
+
+        }
+    }
+
+    @SubscribeEvent
+    public void invoke(LivingDeathEvent event) {
+        if (event.entityLiving.worldObj.isRemote) return;
+
+        DamageSource source = event.source;
+        EntityLivingBase entity = event.entityLiving;
+
+        Entity attacker = source.getEntity();
+
+        if (attacker instanceof EntityPlayer) {
+            doExcalibur(
+              (EntityPlayer) attacker,
+              (EntityPlayer) attacker
+            );
+        } else if (attacker instanceof EntityNPCInterface) {
+            EntityNPCInterface npc = (EntityNPCInterface) event.source.getEntity();
+
+            Line line = npc.advanced.getKillLine();
+
+            if (line != null) {
+                npc.saySurrounding(
+                  line.formatTarget(entity)
+                );
+            }
+
+            NPCKillEntityEvent bus = EventBus.callTo(
+              new NPCKillEntityEvent(
+                (EntityLiving) entity,
+                npc
+              )
+            );
+
+            if (!bus.isCanceled()) {
+                npc.script.callScript(EnumScriptType.KILLS, "target", entity);
+            }
+        }
+
+        if (entity instanceof EntityNPCInterface) {
+            EntityNPCInterface npc = (EntityNPCInterface) entity;
+
+            EntityPlayer entityPlayer = attacker instanceof EntityPlayer ? (EntityPlayer) attacker : null;
+
+            if (npc.advanced.role == EnumRoleType.Follower && entityPlayer == null) {
+                entityPlayer = ((RoleFollower) npc.roleInterface).owner;
+            }
+
+            if (entityPlayer != null) {
+                NPCDeathEvent npcDeathEvent = EventBus.callTo(
+                  new NPCDeathEvent(
+                    npc,
+                    entityPlayer
+                  )
+                );
+
+                if (!npcDeathEvent.isCanceled()) {
+                    doQuest(entityPlayer, entity, true);
+                    doFactionPoints(entityPlayer, npc);
+                }
+            }
+
+        }
 //
-//	@SubscribeEvent
-//	public void onUpdate(LivingUpdateEvent event){
-//		if(!(event.entityLiving instanceof EntityPlayer))
-//			return;
-//		EntityPlayer player = (EntityPlayer) event.entityLiving;
-//		if(exps.containsKey(player.getCommandSenderName())){
-//			int prevExp = exps.get(player.getCommandSenderName());
-//			if(prevExp > player.experienceTotal){				
-//				player.addChatMessage(new ChatComponentText("Omg exp was gotten:" + (player.experienceTotal - prevExp)));
-//			}
-//			else if(prevExp < player.experienceTotal){				
-//				player.addChatMessage(new ChatComponentText("Omg exp was lost:" + (prevExp - player.experienceTotal)));
-//			}
-//		}
-//		exps.put(player.getCommandSenderName(), player.experienceTotal);
-//	}
+//        if (event.entityLiving instanceof EntityPlayer) {
+//            PlayerData data = PlayerDataController.instance.getPlayerData((EntityPlayer) event.entityLiving);
+//            data.saveNBTData(null);
+//        } Why it's saving?
+    }
 
-	@SubscribeEvent
-	public void invoke(EntityInteractEvent event) {
-		ItemStack item = event.entityPlayer.getCurrentEquippedItem();
-		if(item == null)
-			return;
-		boolean isRemote = event.entityPlayer.worldObj.isRemote;
-		boolean npcInteracted = event.target instanceof EntityNPCInterface;
+    private void doExcalibur(EntityPlayer player, EntityLivingBase entity) {
+        ItemStack item = player.getCurrentEquippedItem();
+        if (item == null || item.getItem() != CustomItems.excalibur)
+            return;
+        Server.sendData((EntityPlayerMP) player, EnumPacketClient.PLAY_MUSIC, "customnpcs:songs.excalibur");
+        player.addChatMessage(new ChatComponentTranslation("<" + StatCollector.translateToLocal(item.getItem().getUnlocalizedName() + ".name") + "> " + ItemExcalibur.quotes[player.getRNG().nextInt(ItemExcalibur.quotes.length)]));
+    }
 
-		if(!isRemote && CustomNpcs.OpsOnly && !MinecraftServer.getServer().getConfigurationManager().func_152596_g(event.entityPlayer.getGameProfile())){
-			return;
-		}
-		
-		if(!isRemote && item.getItem() == CustomItems.soulstoneEmpty && event.target instanceof EntityLivingBase) {
-			((ItemSoulstoneEmpty)item.getItem()).store((EntityLivingBase)event.target, item, event.entityPlayer);			
-		}
-		
-		if(item.getItem() == CustomItems.wand && npcInteracted && !isRemote){
-			if (!CustomNpcsPermissions.Instance.hasPermission(event.entityPlayer, CustomNpcsPermissions.NPC_GUI)){
-				return;
-			}
-			event.setCanceled(true);
-			NoppesUtilServer.sendOpenGui(event.entityPlayer, EnumGuiType.MainMenuDisplay, (EntityNPCInterface) event.target);
-		}
-		else if(item.getItem() == CustomItems.cloner && !isRemote && !(event.target instanceof EntityPlayer)){
-			NBTTagCompound compound = new NBTTagCompound();
-			if(!event.target.writeToNBTOptional(compound))
-				return;
-			PlayerData data = PlayerDataController.instance.getPlayerData(event.entityPlayer);
-			ServerCloneController.Instance.cleanTags(compound);
-			if(!Server.sendData((EntityPlayerMP)event.entityPlayer, EnumPacketClient.CLONE, compound))
-				event.entityPlayer.addChatMessage(new ChatComponentText("Entity too big to clone"));
-			data.cloned = compound;
-			event.setCanceled(true);
-		}
-		else if(item.getItem() == CustomItems.scripter && !isRemote && npcInteracted){
-			if(!CustomNpcsPermissions.Instance.hasPermission(event.entityPlayer, CustomNpcsPermissions.NPC_GUI))
-				return;
-	    	NoppesUtilServer.setEditingNpc(event.entityPlayer, (EntityNPCInterface)event.target);
-			event.setCanceled(true);
-        	Server.sendData((EntityPlayerMP)event.entityPlayer, EnumPacketClient.GUI, EnumGuiType.Script.ordinal());
-		}
-		else if(item.getItem() == CustomItems.mount){
-			if(!CustomNpcsPermissions.Instance.hasPermission(event.entityPlayer, CustomNpcsPermissions.TOOL_MOUNTER))
-				return;
-			event.setCanceled(true);
-	    	mounted = event.target;
-	    	if(isRemote)
-	    		CustomNpcs.proxy.openGui(MathHelper.floor_double(mounted.posX), MathHelper.floor_double(mounted.posY), MathHelper.floor_double(mounted.posZ), EnumGuiType.MobSpawnerMounter, event.entityPlayer);
-		}
-		else if(item.getItem() == CustomItems.wand && event.target instanceof EntityVillager){
-			if(!CustomNpcsPermissions.Instance.hasPermission(event.entityPlayer, CustomNpcsPermissions.EDIT_VILLAGER))
-				return;
-			event.setCanceled(true);
-			Merchant = (EntityVillager)event.target;
-			
-			if(!isRemote){
-				EntityPlayerMP player = (EntityPlayerMP) event.entityPlayer;
-				player.openGui(CustomNpcs.instance, EnumGuiType.MerchantAdd.ordinal(), player.worldObj, 0, 0, 0);
-		        MerchantRecipeList merchantrecipelist = Merchant.getRecipes(player);
-	
-		        if (merchantrecipelist != null)
-		        {
-	            	Server.sendData(player, EnumPacketClient.VILLAGER_LIST, merchantrecipelist);
-		        }
-			}
-		}
-		
-	}
-	
-	@SubscribeEvent
-	public void invoke(LivingHurtEvent event) {
-		if(!(event.entityLiving instanceof EntityPlayer))
-			return;
-		
-		EntityPlayer player = (EntityPlayer) event.entityLiving;
-		if(event.source.isUnblockable() || event.source.isFireDamage())
-			return;
-		if(!player.isBlocking())
-			return;
-		ItemStack item = player.getCurrentEquippedItem();
-		if(item == null || !(item.getItem() instanceof ItemShield))
-			return;
-		if(((ItemShield)item.getItem()).material.getDamageVsEntity() < player.getRNG().nextInt(9))
-			return;
-		float damage = item.getItemDamage() + event.ammount;
-		
-		item.damageItem((int) event.ammount, player);
+    private void doFactionPoints(EntityPlayer player, EntityNPCInterface npc) {
+        FactionOptions options = npc.advanced.factions;
 
-		if(damage > item.getMaxDamage())
-			event.ammount = damage - item.getMaxDamage();
-		else{
-			event.ammount = 0;
-			event.setCanceled(true);
-		}
-	}
-	
-	@SubscribeEvent
-	public void invoke(PlayerInteractEvent event) {
-		EntityPlayer player = event.entityPlayer;
-		Block block = player.worldObj.getBlock(event.x, event.y, event.z);
-		if(event.action == Action.LEFT_CLICK_BLOCK && player.getHeldItem() != null && player.getHeldItem().getItem() == CustomItems.teleporter){
-			event.setCanceled(true);
-		}
-		
-		if(block == Blocks.crafting_table && event.action == Action.RIGHT_CLICK_BLOCK && !player.worldObj.isRemote){
-			RecipeController controller = RecipeController.instance;
-	        NBTTagList list = new NBTTagList();
-	        int i = 0;
-	        for(RecipeCarpentry recipe : controller.globalRecipes.values()){
-	        	list.appendTag(recipe.writeNBT());
-	        	i++;
-	        	if(i % 10 == 0){
-	    	        NBTTagCompound compound = new NBTTagCompound();
-	    	        compound.setTag("recipes", list);
-	    	        Server.sendData((EntityPlayerMP)player, EnumPacketClient.SYNCRECIPES_ADD, compound);
-	    	        list = new NBTTagList();
-	        	}
-	        }
+        FactionGainPointsEvent event = EventBus.callTo(
+          new FactionGainPointsEvent(
+            options,
+            player
+          )
+        );
 
-        	if(i % 10 != 0){
-    	        NBTTagCompound compound = new NBTTagCompound();
-    	        compound.setTag("recipes", list);
-    	        Server.sendData((EntityPlayerMP)player, EnumPacketClient.SYNCRECIPES_ADD, compound);
-        	}
-	        Server.sendData((EntityPlayerMP)player, EnumPacketClient.SYNCRECIPES_WORKBENCH);
-		}		
-		if(block == CustomItems.carpentyBench && event.action == Action.RIGHT_CLICK_BLOCK && !player.worldObj.isRemote){
-			RecipeController controller = RecipeController.instance;
-	        NBTTagList list = new NBTTagList();
-	        int i = 0;
-	        for(RecipeCarpentry recipe : controller.anvilRecipes.values()){
-	        	list.appendTag(recipe.writeNBT());
-	        	i++;
-	        	if(i % 10 == 0){
-	    	        NBTTagCompound compound = new NBTTagCompound();
-	    	        compound.setTag("recipes", list);
-	    	        Server.sendData((EntityPlayerMP)player, EnumPacketClient.SYNCRECIPES_ADD, compound);
-	    	        list = new NBTTagList();
-	        	}
-	        }
+        if (event.isCanceled()) return;
 
-        	if(i % 10 != 0){
-    	        NBTTagCompound compound = new NBTTagCompound();
-    	        compound.setTag("recipes", list);
-    	        Server.sendData((EntityPlayerMP)player, EnumPacketClient.SYNCRECIPES_ADD, compound);
-        	}
-	        Server.sendData((EntityPlayerMP)player, EnumPacketClient.SYNCRECIPES_CARPENTRYBENCH);
-		}
-		if((block == CustomItems.banner || block == CustomItems.wallBanner || block == CustomItems.sign)  && event.action == Action.RIGHT_CLICK_BLOCK){
-			ItemStack item = player.inventory.getCurrentItem();
-			if(item == null || item.getItem() == null)
-				return;
-			int y = event.y;
-			int meta = player.worldObj.getBlockMetadata(event.x, event.y, event.z);
-			if(meta >= 7)
-				y--;
-			TileBanner tile = (TileBanner)player.worldObj.getTileEntity(event.x, y, event.z);
-			if(!tile.canEdit()){
-		        if(item.getItem() == CustomItems.wand && CustomNpcsPermissions.hasPermission(player, CustomNpcsPermissions.EDIT_BLOCKS)){
-		        	tile.time = System.currentTimeMillis();
-		        	if(player.worldObj.isRemote)
-		        		player.addChatComponentMessage(new ChatComponentTranslation("availability.editIcon"));
-		        }
-				return;
-			}
+        options.addPoints(player);
+    }
 
-        	if(!player.worldObj.isRemote){
-				tile.icon = item.copy();
-		    	player.worldObj.markBlockForUpdate(event.x, y, event.z);
-		    	event.setCanceled(true);
-        	}
-	    	
-		}
-	}
+    private void doQuest(EntityPlayer player, EntityLivingBase entity, boolean all) {
+        PlayerQuestData playerdata = PlayerDataController.instance.getPlayerData(player).questData;
+        boolean change = false;
+        String entityName = EntityList.getEntityString(entity);
 
-	@SubscribeEvent
-	public void invoke(LivingDeathEvent event) {
-		if(event.entityLiving.worldObj.isRemote)
-			return;
-		if(event.source.getEntity() != null){
-			if(event.source.getEntity() instanceof EntityPlayer){
-				doExcalibur((EntityPlayer) event.source.getEntity(),event.entityLiving);
-			}
-			
-			if(event.source.getEntity() instanceof EntityNPCInterface && event.entityLiving != null){
-				EntityNPCInterface npc = (EntityNPCInterface) event.source.getEntity();
-				Line line = npc.advanced.getKillLine();
-				if(line != null)
-					npc.saySurrounding(line.formatTarget(event.entityLiving));
+        for (QuestData data : playerdata.activeQuests.values()) {
+            if (data.quest.type != EnumQuestType.Kill && data.quest.type != EnumQuestType.AreaKill)
+                continue;
+            if (data.quest.type == EnumQuestType.AreaKill && all) {
+                List<EntityPlayer> list = player.worldObj.getEntitiesWithinAABB(EntityPlayer.class, entity.boundingBox.expand(10, 10, 10));
+                for (EntityPlayer pl : list)
+                    if (pl != player)
+                        doQuest(pl, entity, false);
 
-				npc.script.callScript(EnumScriptType.KILLS, "target", event.entityLiving);
-			}
-			
-			EntityPlayer player = null;
-			if(event.source.getEntity() instanceof EntityPlayer)
-				player = (EntityPlayer) event.source.getEntity();
-			else if(event.source.getEntity() instanceof EntityNPCInterface && ((EntityNPCInterface)event.source.getEntity()).advanced.role == EnumRoleType.Follower)
-				player = ((RoleFollower)((EntityNPCInterface)event.source.getEntity()).roleInterface).owner;
-			if(player != null){
-				doQuest(player, event.entityLiving, true);
-		
-				if(event.entityLiving instanceof EntityNPCInterface)
-					doFactionPoints(player, (EntityNPCInterface)event.entityLiving);
-			}
-		}
-		if(event.entityLiving instanceof EntityPlayer){
-			PlayerData data = PlayerDataController.instance.getPlayerData((EntityPlayer)event.entityLiving);
-			data.saveNBTData(null);
-		}
-	}
+            }
+            String name = entityName;
+            QuestKill quest = (QuestKill) data.quest.questInterface;
+            if (quest.targets.containsKey(entity.getCommandSenderName()))
+                name = entity.getCommandSenderName();
+            else if (!quest.targets.containsKey(name))
+                continue;
+            HashMap<String, Integer> killed = quest.getKilled(data);
+            if (killed.containsKey(name) && killed.get(name) >= quest.targets.get(name))
+                continue;
+            int amount = 0;
+            if (killed.containsKey(name))
+                amount = killed.get(name);
+            killed.put(name, amount + 1);
+            quest.setKilled(data, killed);
+            change = true;
+        }
+        if (!change)
+            return;
 
-	private void doExcalibur(EntityPlayer player, EntityLivingBase entity) {
-		ItemStack item = player.getCurrentEquippedItem();
-		if(item == null || item.getItem() != CustomItems.excalibur)
-			return;
-		Server.sendData((EntityPlayerMP)player, EnumPacketClient.PLAY_MUSIC, "customnpcs:songs.excalibur");
-		player.addChatMessage(new ChatComponentTranslation("<" + StatCollector.translateToLocal(item.getItem().getUnlocalizedName() + ".name") + "> " + ItemExcalibur.quotes[player.getRNG().nextInt(ItemExcalibur.quotes.length)]));
-	}
+        playerdata.checkQuestCompletion(player, EnumQuestType.Kill);
+    }
 
-	private void doFactionPoints(EntityPlayer player, EntityNPCInterface npc) {
-		npc.advanced.factions.addPoints(player);
-	}
+    @SubscribeEvent
+    public void pickUp(EntityItemPickupEvent event) {
+        if (event.entityPlayer.worldObj.isRemote)
+            return;
+        PlayerQuestData playerdata = PlayerDataController.instance.getPlayerData(event.entityPlayer).questData;
+        playerdata.checkQuestCompletion(event.entityPlayer, EnumQuestType.Item);
+    }
 
-	private void doQuest(EntityPlayer player, EntityLivingBase entity, boolean all) {
-		PlayerQuestData playerdata = PlayerDataController.instance.getPlayerData(player).questData;
-		boolean change = false;
-		String entityName = EntityList.getEntityString(entity);		
-		
-		for(QuestData data : playerdata.activeQuests.values()){
-			if(data.quest.type != EnumQuestType.Kill && data.quest.type != EnumQuestType.AreaKill)
-				continue;
-			if(data.quest.type == EnumQuestType.AreaKill && all){
-				List<EntityPlayer> list = player.worldObj.getEntitiesWithinAABB(EntityPlayer.class, entity.boundingBox.expand(10, 10, 10));
-				for(EntityPlayer pl : list)
-					if(pl != player)
-						doQuest(pl, entity, false);
-			
-			}
-			String name = entityName;
-			QuestKill quest = (QuestKill) data.quest.questInterface;
-			if(quest.targets.containsKey(entity.getCommandSenderName()))
-				name = entity.getCommandSenderName();
-			else if(!quest.targets.containsKey(name))
-				continue;
-			HashMap<String, Integer> killed = quest.getKilled(data);
-			if(killed.containsKey(name) && killed.get(name) >= quest.targets.get(name))
-				continue;
-			int amount = 0;
-			if(killed.containsKey(name))
-				amount = killed.get(name);
-			killed.put(name, amount + 1);
-			quest.setKilled(data, killed);
-			change = true;
-		}
-		if(!change)
-			return;
-		
-		playerdata.checkQuestCompletion(player,EnumQuestType.Kill);
-	}
+    @SubscribeEvent
+    public void world(EntityJoinWorldEvent event) {
+        if (event.world.isRemote || !(event.entity instanceof EntityPlayer))
+            return;
+        PlayerData data = PlayerDataController.instance.getPlayerData((EntityPlayer) event.entity);
+        data.updateCompanion(event.world);
+    }
 
-	@SubscribeEvent
-	public void pickUp(EntityItemPickupEvent event){
-		if(event.entityPlayer.worldObj.isRemote)
-			return;
-		PlayerQuestData playerdata = PlayerDataController.instance.getPlayerData(event.entityPlayer).questData;
-		playerdata.checkQuestCompletion(event.entityPlayer, EnumQuestType.Item);
-	}
-
-	@SubscribeEvent
-	public void world(EntityJoinWorldEvent event){
-		if(event.world.isRemote || !(event.entity instanceof EntityPlayer))
-			return;
-		PlayerData data = PlayerDataController.instance.getPlayerData((EntityPlayer) event.entity);
-		data.updateCompanion(event.world);
-	}
-
-	@SubscribeEvent
-	public void populateChunk(PopulateChunkEvent.Post event){
-		NPCSpawning.performWorldGenSpawning(event.world, event.chunkX, event.chunkZ, event.rand);
-	}
+    @SubscribeEvent
+    public void populateChunk(PopulateChunkEvent.Post event) {
+        NPCSpawning.performWorldGenSpawning(event.world, event.chunkX, event.chunkZ, event.rand);
+    }
 }

--- a/src/main/java/noppes/npcs/controllers/FactionOptions.java
+++ b/src/main/java/noppes/npcs/controllers/FactionOptions.java
@@ -3,6 +3,8 @@ package noppes.npcs.controllers;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentTranslation;
+import noppes.npcs.event.FactionGainPointsEvent;
+import noppes.npcs.util.EventBus;
 
 public class FactionOptions {
 
@@ -59,6 +61,14 @@ public class FactionOptions {
 		if(!faction.hideFaction){
 			String message = decrease?"faction.decreasepoints":"faction.increasepoints";
 			player.addChatMessage(new ChatComponentTranslation(message, faction.name, points));
+		}
+
+		FactionGainPointsEvent event = EventBus.callTo(
+				new FactionGainPointsEvent(this, player)
+		);
+
+		if(event.isCanceled()) {
+			return;
 		}
 		
 		data.increasePoints(factionId, decrease?-points:points);

--- a/src/main/java/noppes/npcs/controllers/PlayerData.java
+++ b/src/main/java/noppes/npcs/controllers/PlayerData.java
@@ -20,145 +20,145 @@ import noppes.npcs.util.NBTJsonUtil;
 import java.io.File;
 import java.io.FileInputStream;
 
-public class PlayerData implements IExtendedEntityProperties{
-	public PlayerDialogData dialogData = new PlayerDialogData();
-	public PlayerBankData bankData = new PlayerBankData();
-	public PlayerQuestData questData = new PlayerQuestData();
-	public PlayerTransportData transportData = new PlayerTransportData();
-	public PlayerFactionData factionData = new PlayerFactionData();
-	public PlayerItemGiverData itemgiverData = new PlayerItemGiverData();
-	public PlayerMailData mailData = new PlayerMailData();
-	public DataTimers timers = new DataTimers(this);
+public class PlayerData implements IExtendedEntityProperties {
+    public PlayerDialogData dialogData = new PlayerDialogData();
+    public PlayerBankData bankData = new PlayerBankData();
+    public PlayerQuestData questData = new PlayerQuestData();
+    public PlayerTransportData transportData = new PlayerTransportData();
+    public PlayerFactionData factionData = new PlayerFactionData();
+    public PlayerItemGiverData itemgiverData = new PlayerItemGiverData();
+    public PlayerMailData mailData = new PlayerMailData();
+    public DataTimers timers = new DataTimers(this);
 
-	public EntityNPCInterface editingNpc;
-	public NBTTagCompound cloned;
-	
-	public EntityPlayer player;
+    public EntityNPCInterface editingNpc;
+    public NBTTagCompound cloned;
 
-	public String playername = "";
-	public String uuid = "";
+    public EntityPlayer player;
 
-	private EntityNPCInterface activeCompanion = null;
-	public int companionID = 0;
+    public String playername = "";
+    public String uuid = "";
 
-	public boolean isGUIOpen = false;
+    private EntityNPCInterface activeCompanion = null;
+    public int companionID = 0;
 
-	@Override
-	public void saveNBTData(NBTTagCompound compound) {
-		PlayerDataController.instance.savePlayerData(getNBT(), player.getPersistentID());
-	}
+    public boolean isGUIOpen = false;
 
-	@Override
-	public void loadNBTData(NBTTagCompound compound) {
-		setNBT(
-			PlayerDataController.instance.loadPlayerData(player.getPersistentID())
-		);
-	}
+    @Override
+    public void saveNBTData(NBTTagCompound compound) {
+        PlayerDataController.instance.savePlayerData(getNBT(), player.getPersistentID());
+    }
 
-	public void setNBT(NBTTagCompound data){
-		dialogData.loadNBTData(data);
-		bankData.loadNBTData(data);
-		questData.loadNBTData(data);
-		transportData.loadNBTData(data);
-		factionData.loadNBTData(data);
-		itemgiverData.loadNBTData(data);
-		mailData.loadNBTData(data);
-		timers.readFromNBT(data);
+    @Override
+    public void loadNBTData(NBTTagCompound compound) {
+        PlayerDataController.instance.loadPlayerData(
+          player.getUniqueID()
+        ).thenAccept(this::setNBT);
+    }
 
-		if(player != null){
-			playername = player.getCommandSenderName();
-			uuid = player.getPersistentID().toString();
-		}
-		else{
-			playername = data.getString("PlayerName");
-			uuid = data.getString("UUID");
-		}
-		companionID = data.getInteger("PlayerCompanionId");
-		if(data.hasKey("PlayerCompanion") && !hasCompanion()){
-			EntityCustomNpc npc = new EntityCustomNpc(player.worldObj);
-			npc.readEntityFromNBT(data.getCompoundTag("PlayerCompanion"));
-			npc.setPosition(player.posX, player.posY, player.posZ);
-			if(npc.advanced.role == EnumRoleType.Companion){
-				setCompanion(npc);
-				((RoleCompanion)npc.roleInterface).setSitting(false);
-				player.worldObj.spawnEntityInWorld(npc);
-			}
-		}
-		isGUIOpen = data.getBoolean("isGUIOpen");
-	}
-	public NBTTagCompound getNBT() {
-		if(player != null){
-			playername = player.getCommandSenderName();
-			uuid = player.getPersistentID().toString();
-		}
-		NBTTagCompound compound = new NBTTagCompound();
-		dialogData.saveNBTData(compound);
-		bankData.saveNBTData(compound);
-		questData.saveNBTData(compound);
-		transportData.saveNBTData(compound);
-		factionData.saveNBTData(compound);
-		itemgiverData.saveNBTData(compound);
-		mailData.saveNBTData(compound);
-		timers.writeToNBT(compound);
+    public void setNBT(NBTTagCompound data) {
+        dialogData.loadNBTData(data);
+        bankData.loadNBTData(data);
+        questData.loadNBTData(data);
+        transportData.loadNBTData(data);
+        factionData.loadNBTData(data);
+        itemgiverData.loadNBTData(data);
+        mailData.loadNBTData(data);
+        timers.readFromNBT(data);
 
-		compound.setString("PlayerName", playername);
-		compound.setString("UUID", uuid);
-		compound.setInteger("PlayerCompanionId", companionID);
-		compound.setBoolean("isGUIOpen",isGUIOpen);
-		
-		if(hasCompanion()){
-			NBTTagCompound nbt = new NBTTagCompound();
-			if(activeCompanion.writeToNBTOptional(nbt))
-				compound.setTag("PlayerCompanion", nbt);
-		}
-		return compound;
-	}
+        if (player != null) {
+            playername = player.getCommandSenderName();
+            uuid = player.getPersistentID().toString();
+        } else {
+            playername = data.getString("PlayerName");
+            uuid = data.getString("UUID");
+        }
+        companionID = data.getInteger("PlayerCompanionId");
+        if (data.hasKey("PlayerCompanion") && !hasCompanion()) {
+            EntityCustomNpc npc = new EntityCustomNpc(player.worldObj);
+            npc.readEntityFromNBT(data.getCompoundTag("PlayerCompanion"));
+            npc.setPosition(player.posX, player.posY, player.posZ);
+            if (npc.advanced.role == EnumRoleType.Companion) {
+                setCompanion(npc);
+                ((RoleCompanion) npc.roleInterface).setSitting(false);
+                player.worldObj.spawnEntityInWorld(npc);
+            }
+        }
+        isGUIOpen = data.getBoolean("isGUIOpen");
+    }
 
-	@Override
-	public void init(Entity entity, World world) {
-		
-	}
+    public NBTTagCompound getNBT() {
+        if (player != null) {
+            playername = player.getCommandSenderName();
+            uuid = player.getPersistentID().toString();
+        }
+        NBTTagCompound compound = new NBTTagCompound();
+        dialogData.saveNBTData(compound);
+        bankData.saveNBTData(compound);
+        questData.saveNBTData(compound);
+        transportData.saveNBTData(compound);
+        factionData.saveNBTData(compound);
+        itemgiverData.saveNBTData(compound);
+        mailData.saveNBTData(compound);
+        timers.writeToNBT(compound);
 
-	public void setGUIOpen(boolean bool) {
-		isGUIOpen = bool;
-		saveNBTData(null);
-	}
+        compound.setString("PlayerName", playername);
+        compound.setString("UUID", uuid);
+        compound.setInteger("PlayerCompanionId", companionID);
+        compound.setBoolean("isGUIOpen", isGUIOpen);
 
-	public boolean getGUIOpen() {
-		loadNBTData(null);
-		return isGUIOpen;
-	}
+        if (hasCompanion()) {
+            NBTTagCompound nbt = new NBTTagCompound();
+            if (activeCompanion.writeToNBTOptional(nbt))
+                compound.setTag("PlayerCompanion", nbt);
+        }
+        return compound;
+    }
 
-	public boolean hasCompanion(){
-		return activeCompanion != null && !activeCompanion.isDead;
-	}
+    @Override
+    public void init(Entity entity, World world) {
 
-	public void setCompanion(EntityNPCInterface npc) {
-		if(npc != null && npc.advanced.role != EnumRoleType.Companion)//shouldnt happen
-			return;
-		companionID++;
-		activeCompanion = npc;
-		if(npc != null)
-			((RoleCompanion)npc.roleInterface).companionID = companionID;
-		saveNBTData(null);
-	}
+    }
 
-	public void updateCompanion(World world) {
-		if(!hasCompanion() || world == activeCompanion.worldObj)
-			return;
-		RoleCompanion role = (RoleCompanion) activeCompanion.roleInterface;
-		role.owner = player;
-		if(!role.isFollowing())
-			return;
-		NBTTagCompound nbt = new NBTTagCompound();
-		activeCompanion.writeToNBTOptional(nbt);
-		activeCompanion.isDead = true;
+    public void setGUIOpen(boolean bool) {
+        isGUIOpen = bool;
+        saveNBTData(null);
+    }
 
-		EntityCustomNpc npc = new EntityCustomNpc(world);
-		npc.readEntityFromNBT(nbt);
-		npc.setPosition(player.posX, player.posY, player.posZ);
-		setCompanion(npc);
-		((RoleCompanion)npc.roleInterface).setSitting(false);
-		world.spawnEntityInWorld(npc);
-	}
+    public boolean getGUIOpen() {
+        loadNBTData(null);
+        return isGUIOpen;
+    }
+
+    public boolean hasCompanion() {
+        return activeCompanion != null && !activeCompanion.isDead;
+    }
+
+    public void setCompanion(EntityNPCInterface npc) {
+        if (npc != null && npc.advanced.role != EnumRoleType.Companion)//shouldnt happen
+            return;
+        companionID++;
+        activeCompanion = npc;
+        if (npc != null)
+            ((RoleCompanion) npc.roleInterface).companionID = companionID;
+        saveNBTData(null);
+    }
+
+    public void updateCompanion(World world) {
+        if (!hasCompanion() || world == activeCompanion.worldObj)
+            return;
+        RoleCompanion role = (RoleCompanion) activeCompanion.roleInterface;
+        role.owner = player;
+        if (!role.isFollowing())
+            return;
+        NBTTagCompound nbt = new NBTTagCompound();
+        activeCompanion.writeToNBTOptional(nbt);
+        activeCompanion.isDead = true;
+
+        EntityCustomNpc npc = new EntityCustomNpc(world);
+        npc.readEntityFromNBT(nbt);
+        npc.setPosition(player.posX, player.posY, player.posZ);
+        setCompanion(npc);
+        ((RoleCompanion) npc.roleInterface).setSitting(false);
+        world.spawnEntityInWorld(npc);
+    }
 }

--- a/src/main/java/noppes/npcs/controllers/PlayerData.java
+++ b/src/main/java/noppes/npcs/controllers/PlayerData.java
@@ -45,16 +45,14 @@ public class PlayerData implements IExtendedEntityProperties{
 
 	@Override
 	public void saveNBTData(NBTTagCompound compound) {
-		PlayerDataController.instance.savePlayerData(this);
+		PlayerDataController.instance.savePlayerData(getNBT(), player.getPersistentID());
 	}
 
 	@Override
 	public void loadNBTData(NBTTagCompound compound) {
-		NBTTagCompound data = PlayerDataController.instance.loadPlayerData(player.getPersistentID().toString());
-		if(data.hasNoTags()){
-			data = PlayerDataController.instance.loadPlayerDataOld(player.getCommandSenderName());
-		}
-		setNBT(data);
+		setNBT(
+			PlayerDataController.instance.loadPlayerData(player.getPersistentID())
+		);
 	}
 
 	public void setNBT(NBTTagCompound data){
@@ -162,84 +160,5 @@ public class PlayerData implements IExtendedEntityProperties{
 		setCompanion(npc);
 		((RoleCompanion)npc.roleInterface).setSitting(false);
 		world.spawnEntityInWorld(npc);
-	}
-
-	public static NBTTagCompound loadPlayerDataOld(String player) {
-		File saveDir = CustomNpcs.getWorldSaveDirectory("playerdata");
-		String filename = player;
-		if (player.isEmpty()) {
-			filename = "noplayername";
-		}
-
-		filename = filename + ".dat";
-
-		File file;
-		try {
-			file = new File(saveDir, filename);
-			if (file.exists()) {
-				NBTTagCompound comp = CompressedStreamTools.readCompressed(new FileInputStream(file));
-				file.delete();
-				file = new File(saveDir, filename + "_old");
-				if (file.exists()) {
-					file.delete();
-				}
-
-				return comp;
-			}
-		} catch (Exception var6) {
-			LogWriter.except(var6);
-		}
-
-		try {
-			file = new File(saveDir, filename + "_old");
-			if (file.exists()) {
-				return CompressedStreamTools.readCompressed(new FileInputStream(file));
-			}
-		} catch (Exception var5) {
-			LogWriter.except(var5);
-		}
-
-		return new NBTTagCompound();
-	}
-
-	public static NBTTagCompound loadPlayerData(String player) {
-		File saveDir = CustomNpcs.getWorldSaveDirectory("playerdata");
-		String filename = player;
-		if (player.isEmpty()) {
-			filename = "noplayername";
-		}
-
-		filename = filename + ".json";
-		File file = null;
-
-		try {
-			file = new File(saveDir, filename);
-			if (file.exists()) {
-				return NBTJsonUtil.LoadFile(file);
-			}
-		} catch (Exception var5) {
-			LogWriter.error("Error loading: " + file.getAbsolutePath(), var5);
-		}
-
-		return new NBTTagCompound();
-	}
-
-	public static PlayerData get(EntityPlayer player) {
-		if(player.worldObj.isRemote) {
-			return CustomNpcs.proxy.getPlayerData(player);
-		} else {
-			PlayerData data = new PlayerData();
-			if (data.player == null) {
-				data.player = player;
-				NBTTagCompound compound = loadPlayerData(player.getPersistentID().toString());
-				if (compound.hasNoTags()) {
-					compound = loadPlayerDataOld(player.getCommandSenderName());
-				}
-
-				data.setNBT(compound);
-			}
-
-			return data;
-		}
 	}
 }

--- a/src/main/java/noppes/npcs/controllers/PlayerDataController.java
+++ b/src/main/java/noppes/npcs/controllers/PlayerDataController.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
 import noppes.npcs.CustomNpcs;
+import noppes.npcs.util.NBTJsonUtil;
 
 import java.io.*;
 import java.util.HashMap;
@@ -41,20 +42,30 @@ public class PlayerDataController {
         }
     }
 
-    public NBTTagCompound loadPlayerData(UUID uniqueId) {
+    public CompletableFuture<NBTTagCompound> loadPlayerData(UUID uniqueId) {
         return CompletableFuture.supplyAsync(() -> {
             File data = new File(getSaveDir(), uniqueId + ".dat");
 
-            if (data.exists()) {
-                try {
-                    return from(data);
-                } catch (IOException e) {
-                    e.printStackTrace();
+            try {
+                if (data.exists()) {
+                    try {
+                        return from(data);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                } else {
+                    data = new File(getSaveDir(), uniqueId + ".json");
+
+                    if (data.exists()) {
+                        return NBTJsonUtil.LoadFile(data);
+                    }
                 }
+            } catch (Exception exception) {
+                exception.printStackTrace();
             }
 
             return new NBTTagCompound();
-        }, executorService).join();
+        }, executorService);
     }
 
     public void savePlayerData(NBTTagCompound compound, UUID uuid) {

--- a/src/main/java/noppes/npcs/controllers/PlayerDataController.java
+++ b/src/main/java/noppes/npcs/controllers/PlayerDataController.java
@@ -1,181 +1,172 @@
 package noppes.npcs.controllers;
 
-import java.io.EOFException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.github.luben.zstd.Zstd;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import me.luizotavio.zstd.NBTReaderUtil;
+import me.luizotavio.zstd.NBTWriterUtil;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
 import noppes.npcs.CustomNpcs;
-import noppes.npcs.LogWriter;
-import noppes.npcs.util.NBTJsonUtil;
 
-public class PlayerDataController {		
-	public static PlayerDataController instance;
-	
-	public PlayerDataController(){
-		instance = this;
-	}
-	public File getSaveDir(){
-		try{
-			File file = new File(CustomNpcs.getWorldSaveDirectory(),"playerdata");
-			if(!file.exists())
-				file.mkdir();
-			return file;
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			return null;
-		}
-	}
+import java.io.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
-	public NBTTagCompound loadPlayerDataOld(String player){
-		File saveDir = getSaveDir();
-		String filename = player;
-		if(filename.isEmpty())
-			filename = "noplayername";
-		filename += ".dat";
-		try {
-	        File file = new File(saveDir, filename);
-	        if(file.exists()){
-	        	NBTTagCompound comp = CompressedStreamTools.readCompressed(new FileInputStream(file));
-	        	file.delete();
-		        file = new File(saveDir, filename+"_old");
-		        if(file.exists())
-		        	file.delete();
-	        	return comp;
-	        }
-		} catch (Exception e) {
-			LogWriter.except(e);
-		}
-		try {
-	        File file = new File(saveDir, filename+"_old");
-	        if(file.exists()){
-	        	return CompressedStreamTools.readCompressed(new FileInputStream(file));
-	        }
-	        
-		} catch (Exception e) {
-			LogWriter.except(e);
-		}
+public class PlayerDataController {
+    public static PlayerDataController instance;
 
-		return new NBTTagCompound();
-	}
+    public static ExecutorService executorService = Executors.newFixedThreadPool(3, new ThreadFactoryBuilder()
+      .setNameFormat("CNPC Thread %d")
+      .build()
+    );
 
-	public NBTTagCompound loadPlayerData(String player){
-		File saveDir = getSaveDir();
-		String filename = player;
-		if(filename.isEmpty())
-			filename = "noplayername";
-		filename += ".json";
-		try {
-	        File file = new File(saveDir, filename);
-	        if(file.exists()){
-		        return NBTJsonUtil.LoadFile(file);
-	        }
-		} catch (Exception e) {
-			LogWriter.error("Error loading: " + filename, e);
-		}
+    public PlayerDataController() {
+        instance = this;
+    }
 
-		return new NBTTagCompound();
-	}
-	
-	public void savePlayerData(PlayerData data){
-		NBTTagCompound compound = data.getNBT();
-		String filename = data.uuid + ".json";
-		try {
-			File saveDir = getSaveDir();
-            File file = new File(saveDir, filename+"_new");
-            File file1 = new File(saveDir, filename);
-            NBTJsonUtil.SaveFile(file, compound);
-            if(file1.exists()){
-                file1.delete();
+    public File getSaveDir() {
+        try {
+            File file = new File(CustomNpcs.getWorldSaveDirectory(), "playerdata");
+            if (!file.exists())
+                file.mkdir();
+            return file;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public NBTTagCompound loadPlayerData(UUID uniqueId) {
+        return CompletableFuture.supplyAsync(() -> {
+            File data = new File(getSaveDir(), uniqueId + ".dat");
+
+            if (data.exists()) {
+                try {
+                    return from(data);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
-            file.renameTo(file1);
-		} catch (Exception e) {
-			LogWriter.except(e);
-		}
-	}
-	
-	public PlayerBankData getBankData(EntityPlayer player, int bankId) {
-		Bank bank = BankController.getInstance().getBank(bankId);
-		PlayerBankData data = getPlayerData(player).bankData;
-		if(!data.hasBank(bank.id)){
-			data.loadNew(bank.id);
-		}
-		return data;
-	}
-	
-	public PlayerData getPlayerData(EntityPlayer player){
-		PlayerData data = (PlayerData) player.getExtendedProperties("CustomNpcsData");
-		if(data == null){
-			player.registerExtendedProperties("CustomNpcsData", data = new PlayerData());
-			data.player = player;
-			data.loadNBTData(null);
-		}
-		data.player = player;
-		return data;
-	}
-	public String hasPlayer(String username) {
-        for(String name : getUsernameData().keySet()){
-        	if(name.equalsIgnoreCase(username))
-        		return name;
+
+            return new NBTTagCompound();
+        }, executorService).join();
+    }
+
+    public void savePlayerData(NBTTagCompound compound, UUID uuid) {
+        executorService.submit(() -> {
+            File file = new File(getSaveDir(), uuid + ".dat");
+
+            if (!file.exists()) {
+                try {
+                    file.createNewFile();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            try (DataOutputStream outputStream = new DataOutputStream(new FileOutputStream(file))) {
+                byte[] uncompressed = NBTWriterUtil.writeCompound(compound),
+                  compressed = Zstd.compress(uncompressed);
+
+                outputStream.writeInt(compressed.length);
+                outputStream.writeInt(uncompressed.length);
+
+                outputStream.write(compressed);
+            } catch (Exception exception) {
+                exception.printStackTrace();
+            }
+        });
+    }
+
+    public PlayerBankData getBankData(EntityPlayer player, int bankId) {
+        Bank bank = BankController.getInstance().getBank(bankId);
+        PlayerBankData data = getPlayerData(player).bankData;
+        if (!data.hasBank(bank.id)) {
+            data.loadNew(bank.id);
         }
-		
-		return "";
-	}
-	
-	public PlayerData getDataFromUsername(String username){
-		EntityPlayer player = MinecraftServer.getServer().getConfigurationManager().func_152612_a(username);
-		PlayerData data = null;
-		if(player == null){
-			Map<String, NBTTagCompound> map = getUsernameData();
-			for(String name : map.keySet()){
-				if(name.equalsIgnoreCase(username)){
-					data = new PlayerData();
-					data.setNBT(map.get(name));
-					break;
-				}
-			}
-		}
-		else
-			data = getPlayerData(player);
-		
-		return data;
-	}
-	
-	public void addPlayerMessage(String username, PlayerMail mail) {
-		mail.time = System.currentTimeMillis();
-		
-		EntityPlayer player = MinecraftServer.getServer().getConfigurationManager().func_152612_a(username);
-		PlayerData data = getDataFromUsername(username);
-		data.mailData.playermail.add(mail.copy());
-		savePlayerData(data);
-	}
-	
-	public Map<String, NBTTagCompound> getUsernameData(){
-		Map<String, NBTTagCompound> map = new HashMap<String, NBTTagCompound>();
-        for(File file : getSaveDir().listFiles()){
-        	if(file.isDirectory() || !file.getName().endsWith(".json"))
-        		continue;
-			try {
-				NBTTagCompound compound = NBTJsonUtil.LoadFile(file);
-	        	if(compound.hasKey("PlayerName")){
-	        		map.put(compound.getString("PlayerName"), compound);
-	        	}
-			} catch (Exception e) {
-				LogWriter.error("Error loading: " + file.getAbsolutePath(), e);
-			}
+        return data;
+    }
+
+    public PlayerData getPlayerData(EntityPlayer player) {
+        PlayerData data = (PlayerData) player.getExtendedProperties("CustomNpcsData");
+        if (data == null) {
+            player.registerExtendedProperties("CustomNpcsData", data = new PlayerData());
+            data.player = player;
+            data.loadNBTData(null);
         }
-		return map;
-	}
-	
-	public boolean hasMail(EntityPlayer player) {
-		return getPlayerData(player).mailData.hasMail();
-	}
+        data.player = player;
+        return data;
+    }
+
+    public String hasPlayer(String username) {
+        for (String name : getUsernameData().keySet()) {
+            if (name.equalsIgnoreCase(username))
+                return name;
+        }
+
+        return "";
+    }
+
+    public PlayerData getDataFromUsername(String username) {
+        EntityPlayer player = MinecraftServer.getServer().getConfigurationManager().func_152612_a(username);
+        PlayerData data = null;
+        if (player == null) {
+            Map<String, NBTTagCompound> map = getUsernameData();
+            for (String name : map.keySet()) {
+                if (name.equalsIgnoreCase(username)) {
+                    data = new PlayerData();
+                    data.setNBT(map.get(name));
+                    break;
+                }
+            }
+        } else
+            data = getPlayerData(player);
+
+        return data;
+    }
+
+    public void addPlayerMessage(String username, PlayerMail mail) {
+        mail.time = System.currentTimeMillis();
+
+        PlayerData data = getDataFromUsername(username);
+        data.mailData.playermail.add(mail.copy());
+
+        savePlayerData(data.getNBT(), data.player.getPersistentID());
+    }
+
+    public Map<String, NBTTagCompound> getUsernameData() {
+        Map<String, NBTTagCompound> map = new HashMap<>();
+
+        try {
+            for (File file : getSaveDir().listFiles()) {
+                if (file.isDirectory()) continue;
+
+                NBTTagCompound compound = from(file);
+
+                map.put(
+                  compound.getString("PlayerName"),
+                  compound
+                );
+            }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+
+        return map;
+    }
+
+    private NBTTagCompound from(File file) throws IOException {
+        try (DataInputStream outputStream = new DataInputStream(new FileInputStream(file))) {
+            return NBTReaderUtil.readCompressCompound(outputStream);
+        }
+    }
+
+    public boolean hasMail(EntityPlayer player) {
+        return getPlayerData(player).mailData.hasMail();
+    }
 }

--- a/src/main/java/noppes/npcs/controllers/PlayerQuestData.java
+++ b/src/main/java/noppes/npcs/controllers/PlayerQuestData.java
@@ -98,14 +98,6 @@ public class PlayerQuestData {
             if (inter.isCompleted(player)) {
                 if (!data.isCompleted) {
                     if (!data.quest.complete(player, data)) {
-                        PlayerCompleteQuestEvent event = EventBus.callTo(
-                          new PlayerCompleteQuestEvent(player, data.quest)
-                        );
-
-                        if (event.isCanceled()) {
-                            continue;
-                        }
-
                         Server.sendData((EntityPlayerMP) player, EnumPacketClient.MESSAGE, "quest.completed", data.quest.title);
                         Server.sendData((EntityPlayerMP) player, EnumPacketClient.CHAT, "quest.completed", ": ", data.quest.title);
                     }

--- a/src/main/java/noppes/npcs/controllers/PlayerQuestData.java
+++ b/src/main/java/noppes/npcs/controllers/PlayerQuestData.java
@@ -11,105 +11,113 @@ import noppes.npcs.constants.EnumPacketClient;
 import noppes.npcs.constants.EnumQuestCompletion;
 import noppes.npcs.constants.EnumQuestType;
 import noppes.npcs.entity.EntityNPCInterface;
+import noppes.npcs.event.PlayerCompleteQuestEvent;
 import noppes.npcs.quests.QuestInterface;
+import noppes.npcs.util.EventBus;
 
 public class PlayerQuestData {
-	public HashMap<Integer,QuestData> activeQuests = new HashMap<Integer,QuestData>();
-	public HashMap<Integer,Long> finishedQuests = new HashMap<Integer,Long>();
-	
-	public void loadNBTData(NBTTagCompound mainCompound) {
-		if(mainCompound == null)
-			return;
-		NBTTagCompound compound = mainCompound.getCompoundTag("QuestData");
-		
+    public HashMap<Integer, QuestData> activeQuests = new HashMap<Integer, QuestData>();
+    public HashMap<Integer, Long> finishedQuests = new HashMap<Integer, Long>();
+
+    public void loadNBTData(NBTTagCompound mainCompound) {
+        if (mainCompound == null)
+            return;
+        NBTTagCompound compound = mainCompound.getCompoundTag("QuestData");
+
         NBTTagList list = compound.getTagList("CompletedQuests", 10);
-        if(list != null){
-        	HashMap<Integer,Long> finishedQuests = new HashMap<Integer,Long>();
-            for(int i = 0; i < list.tagCount(); i++)
-            {
+        if (list != null) {
+            HashMap<Integer, Long> finishedQuests = new HashMap<Integer, Long>();
+            for (int i = 0; i < list.tagCount(); i++) {
                 NBTTagCompound nbttagcompound = list.getCompoundTagAt(i);
-                finishedQuests.put(nbttagcompound.getInteger("Quest"),nbttagcompound.getLong("Date"));
+                finishedQuests.put(nbttagcompound.getInteger("Quest"), nbttagcompound.getLong("Date"));
             }
             this.finishedQuests = finishedQuests;
         }
-		
+
         NBTTagList list2 = compound.getTagList("ActiveQuests", 10);
-        if(list2 != null){
-        	HashMap<Integer,QuestData> activeQuests = new HashMap<Integer,QuestData>();
-            for(int i = 0; i < list2.tagCount(); i++)
-            {
+        if (list2 != null) {
+            HashMap<Integer, QuestData> activeQuests = new HashMap<Integer, QuestData>();
+            for (int i = 0; i < list2.tagCount(); i++) {
                 NBTTagCompound nbttagcompound = list2.getCompoundTagAt(i);
                 int id = nbttagcompound.getInteger("Quest");
                 Quest quest = QuestController.instance.quests.get(id);
-                if(quest == null)
-                	continue;
+                if (quest == null)
+                    continue;
                 QuestData data = new QuestData(quest);
                 data.readEntityFromNBT(nbttagcompound);
-                activeQuests.put(id,data);
+                activeQuests.put(id, data);
             }
             this.activeQuests = activeQuests;
         }
-        
-	}
 
-	public void saveNBTData(NBTTagCompound maincompound) {
-		NBTTagCompound compound = new NBTTagCompound();
-		NBTTagList list = new NBTTagList();
-		for(int quest : finishedQuests.keySet()){
-			NBTTagCompound nbttagcompound = new NBTTagCompound();
-			nbttagcompound.setInteger("Quest", quest);
-			nbttagcompound.setLong("Date", finishedQuests.get(quest));
-			list.appendTag(nbttagcompound);
-		}
-		
-		compound.setTag("CompletedQuests", list);
-		
-		NBTTagList list2 = new NBTTagList();
-		for(int quest : activeQuests.keySet()){
-			NBTTagCompound nbttagcompound = new NBTTagCompound();
-			nbttagcompound.setInteger("Quest", quest);
-			activeQuests.get(quest).writeEntityToNBT(nbttagcompound);
-			list2.appendTag(nbttagcompound);
-		}
-		
-		compound.setTag("ActiveQuests", list2);
-		
-		maincompound.setTag("QuestData", compound);
-	}
+    }
 
-	public QuestData getQuestCompletion(EntityPlayer player,EntityNPCInterface npc) {
-		for(QuestData data : activeQuests.values()){
-			Quest quest = data.quest;
-			if(quest != null && quest.completion == EnumQuestCompletion.Npc && quest.completerNpc.equals(npc.getCommandSenderName()) && quest.questInterface.isCompleted(player)){
-				return data;
-			}
-		}
-		return null;
-	}
+    public void saveNBTData(NBTTagCompound maincompound) {
+        NBTTagCompound compound = new NBTTagCompound();
+        NBTTagList list = new NBTTagList();
+        for (int quest : finishedQuests.keySet()) {
+            NBTTagCompound nbttagcompound = new NBTTagCompound();
+            nbttagcompound.setInteger("Quest", quest);
+            nbttagcompound.setLong("Date", finishedQuests.get(quest));
+            list.appendTag(nbttagcompound);
+        }
 
-	public boolean checkQuestCompletion(EntityPlayer player,EnumQuestType type) {
-		boolean bo = false;
-		for(QuestData data : this.activeQuests.values()){
-			if(data.quest.type != type && type != null)
-				continue;
-			
-			QuestInterface inter =  data.quest.questInterface;
-			
-			if(inter.isCompleted(player)){
-				if(!data.isCompleted){
-					if(!data.quest.complete(player,data)){
-						Server.sendData((EntityPlayerMP)player, EnumPacketClient.MESSAGE, "quest.completed", data.quest.title);
-						Server.sendData((EntityPlayerMP)player, EnumPacketClient.CHAT, "quest.completed",": ",data.quest.title);
-					}
-					data.isCompleted = true;
-					bo = true;
-				}
-			}
-			else
-				data.isCompleted = false;
-		}
-		return bo;
-		
-	}
-	
+        compound.setTag("CompletedQuests", list);
+
+        NBTTagList list2 = new NBTTagList();
+        for (int quest : activeQuests.keySet()) {
+            NBTTagCompound nbttagcompound = new NBTTagCompound();
+            nbttagcompound.setInteger("Quest", quest);
+            activeQuests.get(quest).writeEntityToNBT(nbttagcompound);
+            list2.appendTag(nbttagcompound);
+        }
+
+        compound.setTag("ActiveQuests", list2);
+
+        maincompound.setTag("QuestData", compound);
+    }
+
+    public QuestData getQuestCompletion(EntityPlayer player, EntityNPCInterface npc) {
+        for (QuestData data : activeQuests.values()) {
+            Quest quest = data.quest;
+            if (quest != null && quest.completion == EnumQuestCompletion.Npc && quest.completerNpc.equals(npc.getCommandSenderName()) && quest.questInterface.isCompleted(player)) {
+                return data;
+            }
+        }
+        return null;
+    }
+
+    public boolean checkQuestCompletion(EntityPlayer player, EnumQuestType type) {
+        boolean bo = false;
+        for (QuestData data : this.activeQuests.values()) {
+            if (data.quest.type != type && type != null)
+                continue;
+
+            QuestInterface inter = data.quest.questInterface;
+
+            if (inter.isCompleted(player)) {
+                if (!data.isCompleted) {
+                    if (!data.quest.complete(player, data)) {
+                        PlayerCompleteQuestEvent event = EventBus.callTo(
+                          new PlayerCompleteQuestEvent(player, data.quest)
+                        );
+
+                        if (event.isCanceled()) {
+                            continue;
+                        }
+
+                        Server.sendData((EntityPlayerMP) player, EnumPacketClient.MESSAGE, "quest.completed", data.quest.title);
+                        Server.sendData((EntityPlayerMP) player, EnumPacketClient.CHAT, "quest.completed", ": ", data.quest.title);
+                    }
+
+                    data.isCompleted = true;
+                    bo = true;
+                }
+            } else
+                data.isCompleted = false;
+        }
+
+        return bo;
+    }
+
 }

--- a/src/main/java/noppes/npcs/event/FactionGainPointsEvent.java
+++ b/src/main/java/noppes/npcs/event/FactionGainPointsEvent.java
@@ -1,0 +1,26 @@
+package noppes.npcs.event;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+import net.minecraft.entity.Entity;
+import noppes.npcs.controllers.FactionOptions;
+
+@Cancelable
+public class FactionGainPointsEvent extends Event {
+
+    private FactionOptions faction;
+    private Entity source;
+
+    public FactionGainPointsEvent(FactionOptions faction, Entity source) {
+        this.faction = faction;
+        this.source = source;
+    }
+
+    public FactionOptions getFaction() {
+        return faction;
+    }
+
+    public Entity getSource() {
+        return source;
+    }
+}

--- a/src/main/java/noppes/npcs/event/NPCDeathEvent.java
+++ b/src/main/java/noppes/npcs/event/NPCDeathEvent.java
@@ -1,0 +1,35 @@
+package noppes.npcs.event;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.player.EntityPlayer;
+import noppes.npcs.entity.EntityNPCInterface;
+
+@Cancelable
+public class NPCDeathEvent extends Event {
+
+    private EntityLiving npc;
+    private EntityNPCInterface npcInterface;
+
+    private EntityPlayer killer;
+
+    public NPCDeathEvent(EntityLiving npc, EntityPlayer killer) {
+        this.npc = npc;
+        this.killer = killer;
+        this.npcInterface = (EntityNPCInterface) npc;
+    }
+
+    public EntityLiving getNPC() {
+        return npc;
+    }
+
+    public EntityPlayer getKiller() {
+        return killer;
+    }
+
+    public EntityNPCInterface getInterface() {
+        return npcInterface;
+    }
+
+}

--- a/src/main/java/noppes/npcs/event/NPCKillEntityEvent.java
+++ b/src/main/java/noppes/npcs/event/NPCKillEntityEvent.java
@@ -1,0 +1,27 @@
+package noppes.npcs.event;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+import net.minecraft.entity.EntityLiving;
+import noppes.npcs.entity.EntityNPCInterface;
+
+@Cancelable
+public class NPCKillEntityEvent extends Event {
+
+    private EntityLiving entityLiving;
+    private EntityNPCInterface npc;
+
+    public NPCKillEntityEvent(EntityLiving entityLiving, EntityNPCInterface npc) {
+        this.entityLiving = entityLiving;
+        this.npc = npc;
+    }
+
+    public EntityLiving getPlayer() {
+        return entityLiving;
+    }
+
+    public EntityNPCInterface getNPC() {
+        return npc;
+    }
+
+}

--- a/src/main/java/noppes/npcs/event/PlayerCompleteQuestEvent.java
+++ b/src/main/java/noppes/npcs/event/PlayerCompleteQuestEvent.java
@@ -1,0 +1,27 @@
+package noppes.npcs.event;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+import net.minecraft.entity.player.EntityPlayer;
+import noppes.npcs.controllers.Quest;
+
+@Cancelable
+public class PlayerCompleteQuestEvent extends Event {
+
+    private EntityPlayer entityPlayer;
+    private Quest quest;
+
+    public PlayerCompleteQuestEvent(EntityPlayer player, Quest quest) {
+        this.entityPlayer = player;
+        this.quest = quest;
+    }
+
+    public EntityPlayer getPlayer() {
+        return entityPlayer;
+    }
+
+    public Quest getQuest() {
+        return quest;
+    }
+
+}

--- a/src/main/java/noppes/npcs/event/PlayerInteractAtNPCEvent.java
+++ b/src/main/java/noppes/npcs/event/PlayerInteractAtNPCEvent.java
@@ -1,0 +1,27 @@
+package noppes.npcs.event;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+import net.minecraft.entity.player.EntityPlayer;
+import noppes.npcs.entity.EntityNPCInterface;
+
+@Cancelable
+public class PlayerInteractAtNPCEvent extends Event {
+
+    private EntityPlayer entityPlayer;
+    private EntityNPCInterface npcInterface;
+
+    public PlayerInteractAtNPCEvent(EntityPlayer player, EntityNPCInterface npc){
+    	entityPlayer = player;
+    	npcInterface = npc;
+    }
+
+    public EntityPlayer getPlayer(){
+    	return entityPlayer;
+    }
+
+    public EntityNPCInterface getNPC(){
+    	return npcInterface;
+    }
+
+}

--- a/src/main/java/noppes/npcs/util/EventBus.java
+++ b/src/main/java/noppes/npcs/util/EventBus.java
@@ -1,0 +1,14 @@
+package noppes.npcs.util;
+
+import cpw.mods.fml.common.eventhandler.Event;
+import net.minecraftforge.common.MinecraftForge;
+
+public class EventBus {
+
+    public static <T extends Event> T callTo(T event) {
+        MinecraftForge.EVENT_BUS.post(event);
+
+        return event;
+    }
+
+}


### PR DESCRIPTION
Few days ago, I found that CNPC+ Storage Strategy is saving any playerdata inside JSON files with their own encoder/decoder. Many people found spike lags and large files inside their storage, so basically I updated it to use Zstd and then I got a big difference between 2 files:

<img src=https://i.imgur.com/RB0B2GA.png>

The first one, is a `dat` file compressed with Zstd and the another one is the regular file which is stored with JSON.
It show for us `94%` of disk optimization for just `player data`.
There are many things which is stored with JSON, but for now I just updated it to use `player data`.

I think it's a good idea if we could make some forge events to listen to usual custom-npc functions.
I ensure I had tested it in my local machine and seems it's really working.

I make some implementations such as:
* `PlayerCompleteQuestEvent` - Listened before each quest complete from a player;
* `NPCDeathEvent` - Listened on each NPC death event. I guess you think about this as useless event due to scripting mechanics, but for server-side mods it would be used as a good utility;
* `FactionGainPointsEvent` - Listened on each increase factions points;
* `PlayerInteractAtNPCEvent` - Listened on each interact from player to a NPC;
* `NPCKillEntityEvent` - Listened on each NPC kill.