### PR TITLE
Some Extra Soul Stone Options

### DIFF
--- a/src/main/java/noppes/npcs/CustomNpcs.java
+++ b/src/main/java/noppes/npcs/CustomNpcs.java
@@ -123,8 +123,14 @@ public class CustomNpcs {
     @ConfigProp(info = "Normal players can use soulstone on animals")
 	public static boolean SoulStoneAnimals = true;
     
+    @ConfigProp(info = "Normal players can use soulstone on villagers")
+	public static boolean SoulStoneVillagers = false;
+    
     @ConfigProp(info = "Normal players can use soulstone on all npcs")
 	public static boolean SoulStoneNPCs = false;
+    
+    @ConfigProp(info = "Normal players can use soulstone on friendly npcs")
+	public static boolean SoulStoneFriendlyNPCs = false;
 
 	@ConfigProp(info="When set to Minecraft it will use minecrafts font, when Default it will use OpenSans. Can only use fonts installed on your PC")
 	public static String FontType = "Default";

--- a/src/main/java/noppes/npcs/DataAdvanced.java
+++ b/src/main/java/noppes/npcs/DataAdvanced.java
@@ -52,6 +52,8 @@ public class DataAdvanced {
     public boolean attackOtherFactions = false;
     public boolean defendFaction = false;
 	public boolean disablePitch = false;
+	
+	public String soulStonePlayerName;
 
     public DataAdvanced(EntityNPCInterface npc) {
         this.npc = npc;
@@ -83,6 +85,8 @@ public class DataAdvanced {
 
 		compound.setTag("NPCDialogOptions", nbtDialogs(npc.dialogs));
 		
+		compound.setString("SoulStonePlayerName", soulStonePlayerName);
+		
         return compound;
     }
 
@@ -113,6 +117,8 @@ public class DataAdvanced {
         factions.readFromNBT(compound.getCompoundTag("FactionPoints"));
 
 		npc.dialogs = getDialogs(compound.getTagList("NPCDialogOptions", 10));	
+		
+		soulStonePlayerName = compound.getString("SoulStonePlayerName");
     }
 
 	private HashMap<Integer, DialogOption> getDialogs(NBTTagList tagList) {

--- a/src/main/java/noppes/npcs/DataAdvanced.java
+++ b/src/main/java/noppes/npcs/DataAdvanced.java
@@ -56,6 +56,7 @@ public class DataAdvanced {
 	public String soulStonePlayerName = "";
 	public boolean refuseSoulStone = false;
 	public boolean soulStoneInit = false;
+	public int minFactionPointsToSoulStone = -1;
 
     public DataAdvanced(EntityNPCInterface npc) {
         this.npc = npc;
@@ -89,6 +90,7 @@ public class DataAdvanced {
 		
 		compound.setBoolean("RefuseSoulStone", refuseSoulStone);
 		compound.setString("SoulStonePlayerName", soulStonePlayerName);
+		compound.setInteger("MinFactionPointsToSoulStone", minFactionPointsToSoulStone);
 		
         return compound;
     }
@@ -123,6 +125,7 @@ public class DataAdvanced {
 		
 		refuseSoulStone = compound.getBoolean("RefuseSoulStone");
 		soulStonePlayerName = compound.getString("SoulStonePlayerName");
+		minFactionPointsToSoulStone = compound.getInteger("MinFactionPointsToSoulStone");
     }
 
 	private HashMap<Integer, DialogOption> getDialogs(NBTTagList tagList) {

--- a/src/main/java/noppes/npcs/DataAdvanced.java
+++ b/src/main/java/noppes/npcs/DataAdvanced.java
@@ -53,8 +53,9 @@ public class DataAdvanced {
     public boolean defendFaction = false;
 	public boolean disablePitch = false;
 	
-	public boolean refuseSoulStone = false;
 	public String soulStonePlayerName = "";
+	public boolean refuseSoulStone = false;
+	public boolean soulStoneInit = false;
 
     public DataAdvanced(EntityNPCInterface npc) {
         this.npc = npc;

--- a/src/main/java/noppes/npcs/DataAdvanced.java
+++ b/src/main/java/noppes/npcs/DataAdvanced.java
@@ -53,6 +53,7 @@ public class DataAdvanced {
     public boolean defendFaction = false;
 	public boolean disablePitch = false;
 	
+	public boolean refuseSoulStone = false;
 	public String soulStonePlayerName;
 
     public DataAdvanced(EntityNPCInterface npc) {
@@ -85,6 +86,7 @@ public class DataAdvanced {
 
 		compound.setTag("NPCDialogOptions", nbtDialogs(npc.dialogs));
 		
+		compound.setBoolean("RefuseSoulStone", refuseSoulStone);
 		compound.setString("SoulStonePlayerName", soulStonePlayerName);
 		
         return compound;
@@ -118,6 +120,7 @@ public class DataAdvanced {
 
 		npc.dialogs = getDialogs(compound.getTagList("NPCDialogOptions", 10));	
 		
+		refuseSoulStone = compound.getBoolean("RefuseSoulStone");
 		soulStonePlayerName = compound.getString("SoulStonePlayerName");
     }
 

--- a/src/main/java/noppes/npcs/DataAdvanced.java
+++ b/src/main/java/noppes/npcs/DataAdvanced.java
@@ -54,7 +54,7 @@ public class DataAdvanced {
 	public boolean disablePitch = false;
 	
 	public boolean refuseSoulStone = false;
-	public String soulStonePlayerName;
+	public String soulStonePlayerName = "";
 
     public DataAdvanced(EntityNPCInterface npc) {
         this.npc = npc;

--- a/src/main/java/noppes/npcs/EventHooks.java
+++ b/src/main/java/noppes/npcs/EventHooks.java
@@ -118,11 +118,11 @@ public class EventHooks {
     public static void onNPCInit(EntityNPCInterface npc) {
         if(npc == null || npc.wrappedNPC == null)
             return;
-
         noppes.npcs.scripted.event.NpcEvent.InitEvent event = new noppes.npcs.scripted.event.NpcEvent.InitEvent(npc.wrappedNPC);
         ScriptController.Instance.npcScripts.callScript(EnumScriptType.INIT, event);
         npc.script.callScript(EnumScriptType.INIT);
         NpcAPI.EVENT_BUS.post(event);
+        npc.advanced.soulStoneInit = false;
     }
 
     public static void onNPCUpdate(EntityNPCInterface npc) {

--- a/src/main/java/noppes/npcs/client/gui/player/GuiNPCTrader.java
+++ b/src/main/java/noppes/npcs/client/gui/player/GuiNPCTrader.java
@@ -119,7 +119,7 @@ public class GuiNPCTrader extends GuiContainerNPCInterface{
 				}
 				else if (!container.isSlotEnabled(slot, player)) {
 					String title = StatCollector.translateToLocal("trader.slotdisabled");
-					this.fontRendererObj.drawString(title, (xSize - fontRendererObj.getStringWidth(title))/2, 131, 0x00DD00);
+					this.fontRendererObj.drawString(title, (xSize - fontRendererObj.getStringWidth(title))/2, 131, 0xFF4000 );
 				}
 				else{
 		        	String title = StatCollector.translateToLocal("trader.sufficient");

--- a/src/main/java/noppes/npcs/containers/ContainerNPCTrader.java
+++ b/src/main/java/noppes/npcs/containers/ContainerNPCTrader.java
@@ -68,12 +68,12 @@ public class ContainerNPCTrader extends ContainerNpcInterface{
         NoppesUtilPlayer.consumeItem(entityplayer, role.inventoryCurrency.getStackInSlot(i + 18), role.ignoreDamage, role.ignoreNBT);
         ItemStack soldItem = item.copy();
         givePlayer(soldItem, entityplayer);
-        role.addPurchase(i, entityplayer);
+        role.addPurchase(i, entityplayer.getDisplayName());
         return soldItem;
     	
     }
     public boolean isSlotEnabled(int slot, EntityPlayer player) {
-    	return role.isSlotEnabled(slot, player);
+    	return role.isSlotEnabled(slot, player.getDisplayName());
     }
     public boolean canBuy(int slot, EntityPlayer player) {
 		ItemStack currency = role.inventoryCurrency.getStackInSlot(slot);

--- a/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
+++ b/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
@@ -218,7 +218,6 @@ public abstract class EntityNPCInterface extends EntityCreature implements IEnti
 	public void onUpdate(){
 		super.onUpdate();
 		if(this.ticksExisted % 10 == 0) {
-			advanced.soulStoneInit = false;
 			EventHooks.onNPCUpdate(this);
 		}
 		this.timers.update();

--- a/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
+++ b/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
@@ -218,6 +218,7 @@ public abstract class EntityNPCInterface extends EntityCreature implements IEnti
 	public void onUpdate(){
 		super.onUpdate();
 		if(this.ticksExisted % 10 == 0) {
+			advanced.soulStoneInit = false;
 			EventHooks.onNPCUpdate(this);
 		}
 		this.timers.update();

--- a/src/main/java/noppes/npcs/entity/data/DataTimers.java
+++ b/src/main/java/noppes/npcs/entity/data/DataTimers.java
@@ -99,7 +99,7 @@ public class DataTimers implements ITimers {
             DataTimers.Timer timer = (DataTimers.Timer)var3.next();
             NBTTagCompound c = new NBTTagCompound();
             c.setInteger("ID", timer.id);
-            c.setInteger("TimerTicks", timer.id);
+            c.setInteger("TimerTicks", timer.timerTicks);
             c.setBoolean("Repeat", timer.repeat);
             c.setInteger("Ticks", timer.ticks);
             list.appendTag(c);

--- a/src/main/java/noppes/npcs/items/ItemSoulstoneEmpty.java
+++ b/src/main/java/noppes/npcs/items/ItemSoulstoneEmpty.java
@@ -76,17 +76,19 @@ public class ItemSoulstoneEmpty extends Item {
 			return true;
 		if(entity instanceof EntityNPCInterface){
 			EntityNPCInterface npc = (EntityNPCInterface) entity;
-			if(npc.advanced.role == EnumRoleType.Companion){
+			if (npc.advanced.refuseSoulStone) return false;
+			if (npc.getFaction() != null && npc.getFaction().isFriendlyToPlayer(player) 
+					&& CustomNpcs.SoulStoneFriendlyNPCs) return true;
+			if (npc.advanced.role == EnumRoleType.Companion){
 				RoleCompanion role = (RoleCompanion) npc.roleInterface;
 				if(role.getOwner() == player)
 					return true;
 			}
-			if(npc.advanced.role == EnumRoleType.Follower){
+			if (npc.advanced.role == EnumRoleType.Follower){
 				RoleFollower role = (RoleFollower) npc.roleInterface;
 				if(role.getOwner() == player)
 					return !role.refuseSoulStone;
 			}
-			if (npc.getFaction() != null && npc.getFaction().isFriendlyToPlayer(player) && CustomNpcs.SoulStoneFriendlyNPCs) return true;
 			return CustomNpcs.SoulStoneNPCs;
 		}
 		if (entity instanceof EntityAnimal) return CustomNpcs.SoulStoneAnimals;

--- a/src/main/java/noppes/npcs/items/ItemSoulstoneEmpty.java
+++ b/src/main/java/noppes/npcs/items/ItemSoulstoneEmpty.java
@@ -1,9 +1,11 @@
 package noppes.npcs.items;
 
+import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.passive.EntityAnimal;
+import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -17,7 +19,6 @@ import noppes.npcs.controllers.ServerCloneController;
 import noppes.npcs.entity.EntityNPCInterface;
 import noppes.npcs.roles.RoleCompanion;
 import noppes.npcs.roles.RoleFollower;
-import cpw.mods.fml.common.registry.GameRegistry;
 
 public class ItemSoulstoneEmpty extends Item {
 	public ItemSoulstoneEmpty(){
@@ -85,11 +86,11 @@ public class ItemSoulstoneEmpty extends Item {
 				if(role.getOwner() == player)
 					return !role.refuseSoulStone;
 			}
+			if (npc.getFaction() != null && npc.getFaction().isFriendlyToPlayer(player) && CustomNpcs.SoulStoneFriendlyNPCs) return true;
 			return CustomNpcs.SoulStoneNPCs;
 		}
-		if(entity instanceof EntityAnimal)
-			return CustomNpcs.SoulStoneAnimals;
-		
+		if (entity instanceof EntityAnimal) return CustomNpcs.SoulStoneAnimals;
+		if (entity instanceof EntityVillager) return CustomNpcs.SoulStoneVillagers;
 		return false;
 	}
 }

--- a/src/main/java/noppes/npcs/items/ItemSoulstoneEmpty.java
+++ b/src/main/java/noppes/npcs/items/ItemSoulstoneEmpty.java
@@ -15,7 +15,10 @@ import noppes.npcs.CustomNpcs;
 import noppes.npcs.CustomNpcsPermissions;
 import noppes.npcs.NoppesUtilServer;
 import noppes.npcs.constants.EnumRoleType;
+import noppes.npcs.controllers.FactionController;
+import noppes.npcs.controllers.PlayerDataController;
 import noppes.npcs.controllers.ServerCloneController;
+import noppes.npcs.controllers.data.PlayerData;
 import noppes.npcs.entity.EntityNPCInterface;
 import noppes.npcs.roles.RoleCompanion;
 import noppes.npcs.roles.RoleFollower;
@@ -77,8 +80,14 @@ public class ItemSoulstoneEmpty extends Item {
 		if(entity instanceof EntityNPCInterface){
 			EntityNPCInterface npc = (EntityNPCInterface) entity;
 			if (npc.advanced.refuseSoulStone) return false;
-			if (npc.getFaction() != null && npc.getFaction().isFriendlyToPlayer(player) 
-					&& CustomNpcs.SoulStoneFriendlyNPCs) return true;
+			if (CustomNpcs.SoulStoneFriendlyNPCs && npc.getFaction() != null) {
+				int p = npc.advanced.minFactionPointsToSoulStone;
+				if (p == -1 && npc.getFaction().isFriendlyToPlayer(player)) return true;
+				else if (p != -1) {
+					PlayerData data = PlayerDataController.instance.getPlayerData(player);
+					return data.factionData.getFactionPoints(npc.getFaction().getId()) >= p;
+				}
+			}
 			if (npc.advanced.role == EnumRoleType.Companion){
 				RoleCompanion role = (RoleCompanion) npc.roleInterface;
 				if(role.getOwner() == player)

--- a/src/main/java/noppes/npcs/items/ItemSoulstoneFilled.java
+++ b/src/main/java/noppes/npcs/items/ItemSoulstoneFilled.java
@@ -78,7 +78,7 @@ public class ItemSoulstoneFilled extends Item {
     		npc.ai.startPos = new int[]{x, y, z};
     		npc.setHealth(npc.getMaxHealth());
     		npc.setPosition((float)x + 0.5F, npc.getStartYPos(), (float)z + 0.5F);
-    		
+    		npc.advanced.soulStonePlayerName = player.getDisplayName();
     		if(npc.advanced.role == EnumRoleType.Companion && player != null){
     			PlayerData data = PlayerDataController.instance.getPlayerData(player);
     			if(data.hasCompanion())

--- a/src/main/java/noppes/npcs/items/ItemSoulstoneFilled.java
+++ b/src/main/java/noppes/npcs/items/ItemSoulstoneFilled.java
@@ -79,6 +79,7 @@ public class ItemSoulstoneFilled extends Item {
     		npc.setHealth(npc.getMaxHealth());
     		npc.setPosition((float)x + 0.5F, npc.getStartYPos(), (float)z + 0.5F);
     		npc.advanced.soulStonePlayerName = player.getDisplayName();
+    		npc.advanced.soulStoneInit = true;
     		if(npc.advanced.role == EnumRoleType.Companion && player != null){
     			PlayerData data = PlayerDataController.instance.getPlayerData(player);
     			if(data.hasCompanion())

--- a/src/main/java/noppes/npcs/roles/RoleTrader.java
+++ b/src/main/java/noppes/npcs/roles/RoleTrader.java
@@ -118,23 +118,22 @@ public class RoleTrader extends RoleInterface{
 		return false;
 	}
 	
-	public void addPurchase(int slot, EntityPlayer player) {
+	public void addPurchase(int slot, String playerName) {
 		if(slot >= 18 || slot < 0) return;
 		++purchases[slot];
-		++getArrayByName(player.getDisplayName(), playerPurchases)[slot];
+		++getArrayByName(playerName, playerPurchases)[slot];
 	}
 	
-	public boolean isSlotEnabled(int slot, EntityPlayer player) {
+	public boolean isSlotEnabled(int slot, String playerName) {
 		if(slot >= 18 || slot < 0) return false;
 		if (disableSlot[slot] > 0) return false;
-		if (getArrayByName(player.getDisplayName(), playerDisableSlot)[slot] > 0) return false;
+		if (getArrayByName(playerName, playerDisableSlot)[slot] > 0) return false;
 		return true;
 	}
 	
 	public int[] getArrayByName(String name, HashMap<String, int[]> map) {
-		int[] a = map.get(name);
-		if (a == null) a = map.put(name, new int[18]);
-		return a;
+		if (map.get(name) == null) map.put(name, new int[18]);
+		return map.get(name);
 	}
 
 }

--- a/src/main/java/noppes/npcs/scripted/entity/ScriptNpc.java
+++ b/src/main/java/noppes/npcs/scripted/entity/ScriptNpc.java
@@ -1,21 +1,29 @@
 package noppes.npcs.scripted.entity;
 
+import java.util.ArrayList;
+import java.util.UUID;
+
 import net.minecraft.entity.player.EntityPlayer;
 import noppes.npcs.CustomNpcs;
 import noppes.npcs.NoppesUtilServer;
-import noppes.npcs.constants.*;
+import noppes.npcs.constants.EnumAnimation;
+import noppes.npcs.constants.EnumJobType;
+import noppes.npcs.constants.EnumNavType;
+import noppes.npcs.constants.EnumRoleType;
+import noppes.npcs.constants.EnumStandingType;
 import noppes.npcs.controllers.data.Line;
 import noppes.npcs.entity.EntityCustomNpc;
 import noppes.npcs.entity.EntityNPCInterface;
+import noppes.npcs.scripted.NpcAPI;
 import noppes.npcs.scripted.ScriptFaction;
+import noppes.npcs.scripted.constants.AnimationType;
+import noppes.npcs.scripted.constants.EntityType;
+import noppes.npcs.scripted.interfaces.ITimers;
+import noppes.npcs.scripted.interfaces.entity.ICustomNpc;
 import noppes.npcs.scripted.interfaces.entity.IEntityLivingBase;
 import noppes.npcs.scripted.interfaces.entity.IPlayer;
 import noppes.npcs.scripted.interfaces.handler.IOverlayHandler;
 import noppes.npcs.scripted.interfaces.item.IItemStack;
-import noppes.npcs.scripted.constants.AnimationType;
-import noppes.npcs.scripted.constants.EntityType;
-import noppes.npcs.scripted.interfaces.entity.ICustomNpc;
-import noppes.npcs.scripted.interfaces.ITimers;
 import noppes.npcs.scripted.roles.ScriptJobBard;
 import noppes.npcs.scripted.roles.ScriptJobConversation;
 import noppes.npcs.scripted.roles.ScriptJobFollower;
@@ -31,11 +39,7 @@ import noppes.npcs.scripted.roles.ScriptRoleInterface;
 import noppes.npcs.scripted.roles.ScriptRoleMailman;
 import noppes.npcs.scripted.roles.ScriptRoleTrader;
 import noppes.npcs.scripted.roles.ScriptRoleTransporter;
-import noppes.npcs.scripted.NpcAPI;
 import noppes.npcs.util.ValueUtil;
-
-import java.util.ArrayList;
-import java.util.UUID;
 
 public class ScriptNpc<T extends EntityNPCInterface> extends ScriptLiving<T> implements ICustomNpc {
 	public EntityNPCInterface npc;
@@ -869,6 +873,14 @@ public class ScriptNpc<T extends EntityNPCInterface> extends ScriptLiving<T> imp
 	
 	public String getSoulStonePlayerName() {
 		return npc.advanced.soulStonePlayerName;
+	}
+	
+	public boolean getRefuseSoulStone() {
+		return npc.advanced.refuseSoulStone;
+	}
+	
+	public void setRefuseSoulStone(boolean refuse) {
+		npc.advanced.refuseSoulStone = refuse;
 	}
 
 	public void giveItem(IPlayer player, IItemStack item){

--- a/src/main/java/noppes/npcs/scripted/entity/ScriptNpc.java
+++ b/src/main/java/noppes/npcs/scripted/entity/ScriptNpc.java
@@ -862,6 +862,14 @@ public class ScriptNpc<T extends EntityNPCInterface> extends ScriptLiving<T> imp
 		npc.stats.canDespawn = canDespawn;
 		npc.stats.playerSetCanDespawn = canDespawn;
 	}
+	
+	public boolean spawnedFromSoulStone() {
+		return npc.advanced.soulStonePlayerName != null;
+	}
+	
+	public String getSoulStonePlayerName() {
+		return npc.advanced.soulStonePlayerName;
+	}
 
 	public void giveItem(IPlayer player, IItemStack item){
 		npc.givePlayerItem((EntityPlayer) player.getMCEntity(), item.getMCItemStack());

--- a/src/main/java/noppes/npcs/scripted/entity/ScriptNpc.java
+++ b/src/main/java/noppes/npcs/scripted/entity/ScriptNpc.java
@@ -886,6 +886,14 @@ public class ScriptNpc<T extends EntityNPCInterface> extends ScriptLiving<T> imp
 	public boolean isSoulStoneInit() {
 		return npc.advanced.soulStoneInit;
 	}
+	
+	public int getMinPointsToSoulStone() {
+		return npc.advanced.minFactionPointsToSoulStone;
+	}
+	
+	public void setMinPointsToSoulStone(int points) {
+		npc.advanced.minFactionPointsToSoulStone = points;
+	}
 
 	public void giveItem(IPlayer player, IItemStack item){
 		npc.givePlayerItem((EntityPlayer) player.getMCEntity(), item.getMCItemStack());

--- a/src/main/java/noppes/npcs/scripted/entity/ScriptNpc.java
+++ b/src/main/java/noppes/npcs/scripted/entity/ScriptNpc.java
@@ -868,7 +868,7 @@ public class ScriptNpc<T extends EntityNPCInterface> extends ScriptLiving<T> imp
 	}
 	
 	public boolean spawnedFromSoulStone() {
-		return npc.advanced.soulStonePlayerName != null;
+		return !npc.advanced.soulStonePlayerName.equals("");
 	}
 	
 	public String getSoulStonePlayerName() {

--- a/src/main/java/noppes/npcs/scripted/entity/ScriptNpc.java
+++ b/src/main/java/noppes/npcs/scripted/entity/ScriptNpc.java
@@ -882,6 +882,10 @@ public class ScriptNpc<T extends EntityNPCInterface> extends ScriptLiving<T> imp
 	public void setRefuseSoulStone(boolean refuse) {
 		npc.advanced.refuseSoulStone = refuse;
 	}
+	
+	public boolean isSoulStoneInit() {
+		return npc.advanced.soulStoneInit;
+	}
 
 	public void giveItem(IPlayer player, IItemStack item){
 		npc.givePlayerItem((EntityPlayer) player.getMCEntity(), item.getMCItemStack());

--- a/src/main/java/noppes/npcs/scripted/entity/ScriptPlayer.java
+++ b/src/main/java/noppes/npcs/scripted/entity/ScriptPlayer.java
@@ -277,6 +277,40 @@ public class ScriptPlayer<T extends EntityPlayerMP> extends ScriptLivingBase<T> 
 		chat.setChatStyle(style);
 		player.addChatMessage(chat);
 	}
+	
+	public void sendMessage(String message, String color, boolean bold, boolean italic, boolean underlined) {
+		EnumChatFormatting c = getColor(color);
+		if (c == null) return;
+		sendMessage(message, c, bold, italic, underlined);
+	}
+	
+	public void sendMessage(String message, String color, boolean bold, boolean italic, boolean obfuscated, boolean strikethrough, boolean underlined) {
+		EnumChatFormatting c = getColor(color);
+		if (c == null) return;
+		sendMessage(message, c, bold, italic, obfuscated, strikethrough, underlined);
+	}
+	
+	private EnumChatFormatting getColor(String color) {
+		switch (color) {
+		case "black": return EnumChatFormatting.BLACK;
+		case "dark_blue": return EnumChatFormatting.DARK_BLUE;
+		case "dark_green": return EnumChatFormatting.DARK_GREEN;
+		case "dark_aqua": return EnumChatFormatting.DARK_AQUA;
+		case "dark_red": return EnumChatFormatting.DARK_RED;
+		case "dark_purple": return EnumChatFormatting.DARK_PURPLE;
+		case "gold": return EnumChatFormatting.GOLD;
+		case "gray": return EnumChatFormatting.GRAY;
+		case "dark_gray": return EnumChatFormatting.DARK_GRAY;
+		case "blue": return EnumChatFormatting.BLUE;
+		case "green": return EnumChatFormatting.GREEN;
+		case "aqua": return EnumChatFormatting.AQUA;
+		case "red": return EnumChatFormatting.RED;
+		case "light_purple": return EnumChatFormatting.LIGHT_PURPLE;
+		case "yellow": return EnumChatFormatting.YELLOW;
+		case "white": return EnumChatFormatting.WHITE;
+		default: return null;
+		}
+	}
 
 	/**
 	 * @return Return gamemode. 0: Survival, 1: Creative, 2: Adventure

--- a/src/main/java/noppes/npcs/scripted/interfaces/entity/ICustomNpc.java
+++ b/src/main/java/noppes/npcs/scripted/interfaces/entity/ICustomNpc.java
@@ -623,7 +623,17 @@ public interface ICustomNpc<T extends EntityCreature> extends IEntityLiving<T> {
      * @param canDespawn True if the NPC should naturally despawn. False otherwise.
      */
     void setNaturallyDespawns(boolean canDespawn);
-
+    
+    /**
+     * @return true if this npc was spawned by a player using soulstone
+     */
+    boolean spawnedFromSoulStone();
+    
+    /**
+     * @return the name of the player who spawned this npc using soulstone. null if not spawned by soulstone
+     */
+    String getSoulStonePlayerName();
+    
     /**
      * @param player The player to give the item to
      * @param item The item given to the player

--- a/src/main/java/noppes/npcs/scripted/interfaces/entity/ICustomNpc.java
+++ b/src/main/java/noppes/npcs/scripted/interfaces/entity/ICustomNpc.java
@@ -635,6 +635,16 @@ public interface ICustomNpc<T extends EntityCreature> extends IEntityLiving<T> {
     String getSoulStonePlayerName();
     
     /**
+     * @return does this npc refuse to be taken by soul stone 
+     */
+    boolean getRefuseSoulStone();
+    
+    /**
+     * @param refuse set if this npc refuses to be taken by soul stone
+     */
+    void setRefuseSoulStone(boolean refuse);
+    
+    /**
      * @param player The player to give the item to
      * @param item The item given to the player
      */

--- a/src/main/java/noppes/npcs/scripted/interfaces/entity/ICustomNpc.java
+++ b/src/main/java/noppes/npcs/scripted/interfaces/entity/ICustomNpc.java
@@ -7,11 +7,11 @@ package noppes.npcs.scripted.interfaces.entity;
 
 import net.minecraft.entity.EntityCreature;
 import noppes.npcs.scripted.ScriptFaction;
-import noppes.npcs.scripted.interfaces.ISkinOverlay;
+import noppes.npcs.scripted.interfaces.ITimers;
 import noppes.npcs.scripted.interfaces.handler.IOverlayHandler;
 import noppes.npcs.scripted.interfaces.item.IItemStack;
-import noppes.npcs.scripted.interfaces.ITimers;
-import noppes.npcs.scripted.roles.*;
+import noppes.npcs.scripted.roles.ScriptJobInterface;
+import noppes.npcs.scripted.roles.ScriptRoleInterface;
 
 public interface ICustomNpc<T extends EntityCreature> extends IEntityLiving<T> {
     /**
@@ -648,6 +648,22 @@ public interface ICustomNpc<T extends EntityCreature> extends IEntityLiving<T> {
      * @param refuse set if this npc refuses to be taken by soul stone
      */
     void setRefuseSoulStone(boolean refuse);
+    
+    /**
+     * requires SoulStoneFriendlyNPCs in config to be true
+     * -1 by default
+     * if -1, the minimum points are the faction's friendly points
+     * @return the minimum faction points needed to soulstone this npc
+     */
+    int getMinPointsToSoulStone();
+    
+    /**
+     * requires SoulStoneFriendlyNPCs in config to be true
+     * -1 by default
+     * if -1, the minimum points are the faction's friendly points
+     * @param points the minimum faction points needed to soulstone this npc
+     */
+    void setMinPointsToSoulStone(int points);
     
     /**
      * @param player The player to give the item to

--- a/src/main/java/noppes/npcs/scripted/interfaces/entity/ICustomNpc.java
+++ b/src/main/java/noppes/npcs/scripted/interfaces/entity/ICustomNpc.java
@@ -635,6 +635,11 @@ public interface ICustomNpc<T extends EntityCreature> extends IEntityLiving<T> {
     String getSoulStonePlayerName();
     
     /**
+     * @return true if npc was spawned by soul stone. becomes false after the init function is called.
+     */
+    boolean isSoulStoneInit();
+    
+    /**
      * @return does this npc refuse to be taken by soul stone 
      */
     boolean getRefuseSoulStone();

--- a/src/main/java/noppes/npcs/scripted/interfaces/entity/IPlayer.java
+++ b/src/main/java/noppes/npcs/scripted/interfaces/entity/IPlayer.java
@@ -99,6 +99,10 @@ public interface IPlayer<T extends EntityPlayerMP> extends IEntityLivingBase<T> 
     void sendMessage(String message, EnumChatFormatting color, boolean bold, boolean italic, boolean underlined);
 
     void sendMessage(String message, EnumChatFormatting color, boolean bold, boolean italic, boolean obfuscated, boolean strikethrough, boolean underlined);
+    
+    void sendMessage(String message, String color, boolean bold, boolean italic, boolean underlined);
+    
+    void sendMessage(String message, String color, boolean bold, boolean italic, boolean obfuscated, boolean strikethrough, boolean underlined);
 
     /**
      * @return Return gamemode. 0: Survival, 1: Creative, 2: Adventure

--- a/src/main/java/noppes/npcs/scripted/roles/ScriptRoleTrader.java
+++ b/src/main/java/noppes/npcs/scripted/roles/ScriptRoleTrader.java
@@ -1,13 +1,12 @@
 package noppes.npcs.scripted.roles;
 
 import foxz.utils.Market;
-import net.minecraft.entity.player.EntityPlayer;
 import noppes.npcs.entity.EntityNPCInterface;
 import noppes.npcs.roles.RoleTrader;
 import noppes.npcs.scripted.NpcAPI;
-import noppes.npcs.scripted.interfaces.item.IItemStack;
 import noppes.npcs.scripted.constants.RoleType;
 import noppes.npcs.scripted.interfaces.entity.IPlayer;
+import noppes.npcs.scripted.interfaces.item.IItemStack;
 
 public class ScriptRoleTrader extends ScriptRoleInterface{
 	private RoleTrader role;
@@ -160,7 +159,7 @@ public class ScriptRoleTrader extends ScriptRoleInterface{
 	 */
 	public boolean isSlotEnabled(int slot, IPlayer player) {
 		if(slot >= 18 || slot < 0) return false;
-		return role.isSlotEnabled(slot, (EntityPlayer)player.getMCEntity());
+		return role.isSlotEnabled(slot, player.getDisplayName());
 	}
 	
 	/**

--- a/src/main/java/noppes/npcs/scripted/roles/ScriptRoleTrader.java
+++ b/src/main/java/noppes/npcs/scripted/roles/ScriptRoleTrader.java
@@ -55,7 +55,7 @@ public class ScriptRoleTrader extends ScriptRoleInterface{
 	public IItemStack getSellOption(int slot) {
 		if (slot >= 18 || slot < 0) return null;
 		if (role.inventorySold.items.get(slot) == null) return null;
-		return NpcAPI.Instance().getIItemStack(role.inventoryCurrency.items.get(slot));
+		return NpcAPI.Instance().getIItemStack(role.inventorySold.items.get(slot));
 	}
 	
 	/**


### PR DESCRIPTION
-get the name of the player who spawned this npc with soulstone with `ScriptNpc.getSoulStonePlayerName()`
-normal players use soul stone on villagers, enabled through config
-normal players use soul stone on friendly npcs only, enabled through config
-script `player.sendMessage()` uses String as color parameter
-`ScriptNpc.getRefuseSoulStone()` if true normal players can't use soul stone on this npc regardless of other conditions