### PR TITLE
Split releases to have a release without mixin embedded

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,25 @@
+name: Java CI with Gradle
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew SetupCIWorkspace build
+    - name: Build with Gradle (nomixin)
+      run: ./gradlew build -Pnomixin
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Package
+        path: build/libs

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ buildscript {
 }
 
 configurations {
-    mixins
-    compile.extendsFrom(mixins)
+    embed
+    compile.extendsFrom(embed)
     shade
     compile.extendsFrom(shade)
 }
@@ -98,7 +98,7 @@ repositories {
 }
 
 dependencies {
-    mixins('org.spongepowered:mixin:0.7.11-SNAPSHOT') {
+    embed('org.spongepowered:mixin:0.7.11-SNAPSHOT') {
         // Mixin includes a lot of dependencies that are too up-to-date
         exclude module: 'launchwrapper'
         exclude module: 'guava'
@@ -127,34 +127,17 @@ jar {
         attributes.put("MixinConfigs", yourMixinConfig)
     }
 
-}
-
-// a task to run after the reobf task to create another jar with the contents of the mixin dependency
-task MixinsJar(type: Jar, dependsOn: reobf) {
-    classifier = "mixin-included"
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    manifest {
-        attributes.put("TweakClass", "org.spongepowered.asm.launch.MixinTweaker")
-        attributes.put("FMLCorePluginContainsFMLMod", true)
-        attributes.put("ForceLoadAsMod", true)
-        attributes.put("MixinConfigs", yourMixinConfig)
-    }
-    from configurations.mixins.collect {
+    // embed libraries in jar
+    from configurations.embed.collect {
         exclude '**/LICENSE.txt'
-        //exclude signature files (causing a SecurityException error)
-        exclude "**/**.RSA"
-        exclude "**/**.SF"
         it.isDirectory() ? it : zipTree(it)
     }
-    with jar
 }
+
 reobf {
     addExtraSrgFile mixinSrg
 }
 
-artifacts {
-    archives MixinsJar
-}
 afterEvaluate {
     def fixedRelPathToAP = relativePathToMixinAP
     if(fixedRelPathToAP.startsWith('./') || fixedRelPathToAP.startsWith('.\\')){

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ buildscript {
 }
 
 configurations {
-    embed
-    compile.extendsFrom(embed)
+    mixins
+    compile.extendsFrom(mixins)
     shade
     compile.extendsFrom(shade)
 }
@@ -98,7 +98,7 @@ repositories {
 }
 
 dependencies {
-    embed('org.spongepowered:mixin:0.7.11-SNAPSHOT') {
+    mixins('org.spongepowered:mixin:0.7.11-SNAPSHOT') {
         // Mixin includes a lot of dependencies that are too up-to-date
         exclude module: 'launchwrapper'
         exclude module: 'guava'
@@ -127,17 +127,34 @@ jar {
         attributes.put("MixinConfigs", yourMixinConfig)
     }
 
-    // embed libraries in jar
-    from configurations.embed.collect {
-        exclude '**/LICENSE.txt'
-        it.isDirectory() ? it : zipTree(it)
-    }
 }
 
+// a task to run after the reobf task to create another jar with the contents of the mixin dependency
+task MixinsJar(type: Jar, dependsOn: reobf) {
+    classifier = "mixin-included"
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    manifest {
+        attributes.put("TweakClass", "org.spongepowered.asm.launch.MixinTweaker")
+        attributes.put("FMLCorePluginContainsFMLMod", true)
+        attributes.put("ForceLoadAsMod", true)
+        attributes.put("MixinConfigs", yourMixinConfig)
+    }
+    from configurations.mixins.collect {
+        exclude '**/LICENSE.txt'
+        //exclude signature files (causing a SecurityException error)
+        exclude "**/**.RSA"
+        exclude "**/**.SF"
+        it.isDirectory() ? it : zipTree(it)
+    }
+    with jar
+}
 reobf {
     addExtraSrgFile mixinSrg
 }
 
+artifacts {
+    archives MixinsJar
+}
 afterEvaluate {
     def fixedRelPathToAP = relativePathToMixinAP
     if(fixedRelPathToAP.startsWith('./') || fixedRelPathToAP.startsWith('.\\')){

--- a/build.gradle
+++ b/build.gradle
@@ -87,9 +87,15 @@ jar {
 //Add
 //--tweakClass org.spongepowered.asm.launch.MixinTweaker --mixin customnpcs.mixins.json
 //to your client and server program arguments if working in a dev environment.
+def embedMixin = !project.hasProperty("nomixin");
 def yourMixinConfig = 'customnpcs.mixins.json'
 def refMapForYourConfig = 'customnpcs.refmap.json'
 def relativePathToMixinAP = 'tools/mixin-0.8-SNAPSHOT.jar'
+
+if(!embedMixin){
+    version += "+nomixin"
+}
+
 repositories {
     maven {
         name = "sponge"
@@ -98,13 +104,24 @@ repositories {
 }
 
 dependencies {
-    embed('org.spongepowered:mixin:0.7.11-SNAPSHOT') {
-        // Mixin includes a lot of dependencies that are too up-to-date
-        exclude module: 'launchwrapper'
-        exclude module: 'guava'
-        exclude module: 'gson'
-        exclude module: 'commons-io'
-        exclude module: 'log4j-core'
+    if(embedMixin){
+        embed('org.spongepowered:mixin:0.7.11-SNAPSHOT') {
+            // Mixin includes a lot of dependencies that are too up-to-date
+            exclude module: 'launchwrapper'
+            exclude module: 'guava'
+            exclude module: 'gson'
+            exclude module: 'commons-io'
+            exclude module: 'log4j-core'
+        }
+    } else {
+        implementation('org.spongepowered:mixin:0.7.11-SNAPSHOT') {
+            // Mixin includes a lot of dependencies that are too up-to-date
+            exclude module: 'launchwrapper'
+            exclude module: 'guava'
+            exclude module: 'gson'
+            exclude module: 'commons-io'
+            exclude module: 'log4j-core'
+        }
     }
 }
 


### PR DESCRIPTION
Making this PR to allow compatibility with other mods that may shade mixins themselves / depend on external mods that have mixins embedded into them ([gtnh mixins](https://github.com/GTNewHorizons/GTNHMixins) as an example)