### PR TITLE
More NBT serialising and deserialising 

### DIFF
--- a/src/main/java/noppes/npcs/util/NBTJsonUtil.java
+++ b/src/main/java/noppes/npcs/util/NBTJsonUtil.java
@@ -24,8 +24,8 @@ public class NBTJsonUtil {
 		json = json.trim();
 		JsonFile file = new JsonFile(json);
 		if(!json.startsWith("{") || !json.endsWith("}"))
-			throw new JsonException("Not properly incapsulated between { }", file);
-		
+			throw new JsonException("Not properly encapsulated between { }", file);
+
 		NBTTagCompound compound = new NBTTagCompound();
 		FillCompound(compound, file);
 		return compound;
@@ -85,6 +85,16 @@ public class NBTJsonUtil {
 			if(!json.startsWith("]")){
 				throw new JsonException("Expected ]", json);
 			}
+
+			if (json.startsWith("]b")) {
+				json.cut(2);
+				byte[] arr = new byte[list.tagCount()];
+				for(int i = 0; list.tagCount() > 0 ; i++){
+					arr[i] = ((NBTTagInt)list.removeTag(0)).func_150290_f();
+				}
+				return new NBTTagByteArray(arr);
+			}
+
 			json.cut(1);
 
 			if(list.func_150303_d() == 3){
@@ -156,7 +166,19 @@ public class NBTJsonUtil {
 	private static JsonLine ReadTag(String name, NBTBase base, List<JsonLine> list){
 		if(!name.isEmpty())
 			name = "\"" + name + "\": ";
-		if(base.getId() == 8){//NBTTagString
+		if (base.getId() == 7) {//NBTTagByteArray
+			list.add(new JsonLine(name + "["));
+			byte[] bytes = ((NBTTagByteArray) base).func_150292_c();
+
+			for(int i = 0; i < (bytes.length-1); i++) {
+				list.add(new JsonLine(String.format("%s,", bytes[i])));
+			}
+			if (bytes.length > 0) {
+				list.add(new JsonLine(String.format("%s", bytes[bytes.length-1])));
+			}
+			list.add(new JsonLine("]b"));
+		}
+		else if(base.getId() == 8){//NBTTagString
 			String data = ((NBTTagString)base).func_150285_a_();
 			data = data.replace("\"", "\\\""); //replace " with \"
 			list.add(new JsonLine(name + "\"" + data + "\""));
@@ -225,7 +247,8 @@ public class NBTJsonUtil {
 		public boolean reduceTab(){
 			int length = line.length();
 			return length == 1 && (line.endsWith("}") || line.endsWith("]"))
-					|| length == 2 && (line.endsWith("},") ||line.endsWith("],"));
+					   || length == 2 && (line.endsWith("},") ||line.endsWith("],") || line.endsWith("]b"))
+					   || length == 3 && (line.endsWith("]b,"));
 		}
 		
 		public boolean increaseTab(){
@@ -281,6 +304,24 @@ public class NBTJsonUtil {
 			}
 			
 			return "Line: " + lines.length + ", Pos: " + pos + ", Text: " + line;
+		}
+
+		public int findObjectColonIndex() {
+			int trueQuotesAmount = 0;
+
+			for (int i = 0; i < text.length(); i++) {
+				if (text.charAt(i) == '"') {
+					if (i > 1 && text.charAt(i-1) != '\\' || i == 0) {
+						trueQuotesAmount++;
+					}
+				}
+
+				if (trueQuotesAmount == 2) {
+					return text.indexOf(":", i);
+				}
+			}
+
+			return -1;
 		}
 
 		public boolean startsWith(String... ss) {

--- a/src/main/java/noppes/npcs/util/NBTJsonUtil.java
+++ b/src/main/java/noppes/npcs/util/NBTJsonUtil.java
@@ -36,7 +36,7 @@ public class NBTJsonUtil {
 			json.cut(1);
 		if(json.startsWith("}"))
 			return;
-		int index = json.indexOf(":");
+		int index = json.findObjectColonIndex();
 		if(index < 1)
 			throw new JsonException("Expected key after ," ,json);
 		


### PR DESCRIPTION
Hi Kamkeel! 
Recently I had to de- and serialise some NBT and decided to use your NBTUtils for this but faced with issued described below 

Proposals: 
Better experience of converting NBT to json and vice versa 

What I've done:
Since we need to explicitly describe most data types for NBTTag and there are only one Array - `NBTTagIntArray` I decided to follow data type description semantics and added 'b' suffix to end off array to make it possible to differ `ByteArray` from `IntArray`

Why changed:
 - **`NBTJsonUtil.FillCompound`**
Because "a:1" is valid JSON key too. I faced issue that some mods (in my case OpenComputers) has tag names like this, for example:
```json
{
    "id":4303s,
    "Count":1b,
    "tag":{
        "oc:data":{
            "oc:readonly":0b,
            "oc:eeprom":[
                108,
                111,
                99,
                97,
                108
            ]b,
            "oc:label":"EEPROM (Lua BIOS)"
        }
    },
    "Damage":0s
}
```
and previous algorithm looked for just first colon symbol, but it may not be colon we need

So now it looks for key bounds that must be wrapped in quotes without escapes (because "a\\"b" is also a valid JSON key) and only then looks for `text.indexOf(":", keyBoundWithQuoteIndex)` with offset to key length.

 - **`NBTJsonUtil.ReadTag`**
 Default `NBTTagByteArray.toString()`, wondering to me, just gives bytes amount in array in quad braces and not a real bytes array
 but `NBTTagIntArray.toString()` does. So why not to export it in readable format too?

 - **`NBTJsonUtil.ReadValue`**
 According to changing ReadTag to support exporting `NBTTagByteArray` in human-readable way we also need func to convert in back to `NBTTagByteArray`


