### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/docs/index-files/index-1.html
+++ b/docs/index-files/index-1.html
@@ -139,7 +139,7 @@
 <dd>&nbsp;</dd>
 <dt><span class="memberNameLink"><a href="../noppes/npcs/api/entity/IEntityLivingBase.html#addPotionEffect-int-int-int-boolean-">addPotionEffect(int, int, int, boolean)</a></span> - Method in interface noppes.npcs.api.entity.<a href="../noppes/npcs/api/entity/IEntityLivingBase.html" title="interface in noppes.npcs.api.entity">IEntityLivingBase</a></dt>
 <dd>
-<div class="block">Works the same as the <a href="http://minecraft.gamepedia.com/Commands#effect">/effect command</a></div>
+<div class="block">Works the same as the <a href="http://minecraft.wiki/w/Commands">/effect command</a></div>
 </dd>
 <dt><span class="memberNameLink"><a href="../noppes/npcs/api/handler/IRecipeHandler.html#addRecipe-java.lang.String-boolean-net.minecraft.item.ItemStack-java.lang.Object...-">addRecipe(String, boolean, ItemStack, Object...)</a></span> - Method in interface noppes.npcs.api.handler.<a href="../noppes/npcs/api/handler/IRecipeHandler.html" title="interface in noppes.npcs.api.handler">IRecipeHandler</a></dt>
 <dd>&nbsp;</dd>

--- a/docs/noppes/npcs/api/IWorld.html
+++ b/docs/noppes/npcs/api/IWorld.html
@@ -1959,7 +1959,7 @@ var activeTableTab = "activeTableTab";
 <div class="block">Sends a packet from the server to the client everytime its called. Probably should not use this too much.</div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
-<dd><code>particle</code> - Particle name. Particle name list: http://minecraft.gamepedia.com/Particles</dd>
+<dd><code>particle</code> - Particle name. Particle name list: http://minecraft.wiki/w/Particles</dd>
 <dd><code>x</code> - The x position</dd>
 <dd><code>y</code> - The y position</dd>
 <dd><code>z</code> - The z position</dd>

--- a/docs/noppes/npcs/api/entity/IEntityLivingBase.html
+++ b/docs/noppes/npcs/api/entity/IEntityLivingBase.html
@@ -134,7 +134,7 @@ extends <a href="../../../../noppes/npcs/api/entity/IEntity.html" title="interfa
                int&nbsp;duration,
                int&nbsp;strength,
                boolean&nbsp;hideParticles)</code>
-<div class="block">Works the same as the <a href="http://minecraft.gamepedia.com/Commands#effect">/effect command</a></div>
+<div class="block">Works the same as the <a href="http://minecraft.wiki/w/Commands">/effect command</a></div>
 </td>
 </tr>
 <tr id="i1" class="rowColor">
@@ -573,7 +573,7 @@ extends <a href="../../../../noppes/npcs/api/entity/IEntity.html" title="interfa
                      int&nbsp;duration,
                      int&nbsp;strength,
                      boolean&nbsp;hideParticles)</pre>
-<div class="block">Works the same as the <a href="http://minecraft.gamepedia.com/Commands#effect">/effect command</a></div>
+<div class="block">Works the same as the <a href="http://minecraft.wiki/w/Commands">/effect command</a></div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
 <dd><code>effect</code> - </dd>

--- a/docs/noppes/npcs/api/entity/IPlayer.html
+++ b/docs/noppes/npcs/api/entity/IPlayer.html
@@ -1023,7 +1023,7 @@ extends <a href="../../../../noppes/npcs/api/entity/IEntityLivingBase.html" titl
 <dt><span class="paramLabel">Parameters:</span></dt>
 <dd><code>message</code> - The message you want to send. Compatible with formatting codes, which can be found on the attached link.</dd>
 <dt><span class="seeLabel">See Also:</span></dt>
-<dd><a href="https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7e/Minecraft_Formatting.gif/revision/latest/scale-to-width-down/200?cb=20200828001454">Minecraft formatting codes</a></dd>
+<dd><a href="https://minecraft.wiki/images/Minecraft_Formatting.gif?2311f">Minecraft formatting codes</a></dd>
 </dl>
 </li>
 </ul>
@@ -1373,7 +1373,7 @@ extends <a href="../../../../noppes/npcs/api/entity/IEntityLivingBase.html" titl
 <pre>boolean&nbsp;hasAchievement(java.lang.String&nbsp;achievement)</pre>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
-<dd><code>achievement</code> - The achievement id. For a complete list see http://minecraft.gamepedia.com/Achievements</dd>
+<dd><code>achievement</code> - The achievement id. For a complete list see http://minecraft.wiki/w/Achievements</dd>
 <dt><span class="returnLabel">Returns:</span></dt>
 <dd>Returns whether or not the player has this achievement</dd>
 </dl>

--- a/docs/noppes/npcs/scripted/interfaces/IWorld.html
+++ b/docs/noppes/npcs/scripted/interfaces/IWorld.html
@@ -1582,7 +1582,7 @@ var activeTableTab = "activeTableTab";
 <div class="block">Sends a packet from the server to the client everytime its called. Probably should not use this too much.</div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
-<dd><code>particle</code> - Particle name. Particle name list: http://minecraft.gamepedia.com/Particles</dd>
+<dd><code>particle</code> - Particle name. Particle name list: http://minecraft.wiki/w/Particles</dd>
 <dd><code>x</code> - The x position</dd>
 <dd><code>y</code> - The y position</dd>
 <dd><code>z</code> - The z position</dd>

--- a/docs/noppes/npcs/scripted/interfaces/entity/IEntityLivingBase.html
+++ b/docs/noppes/npcs/scripted/interfaces/entity/IEntityLivingBase.html
@@ -134,7 +134,7 @@ extends <a href="../../../../../noppes/npcs/scripted/interfaces/entity/IEntity.h
                int&nbsp;duration,
                int&nbsp;strength,
                boolean&nbsp;hideParticles)</code>
-<div class="block">Works the same as the <a href="http://minecraft.gamepedia.com/Commands#effect">/effect command</a></div>
+<div class="block">Works the same as the <a href="http://minecraft.wiki/w/Commands">/effect command</a></div>
 </td>
 </tr>
 <tr id="i1" class="rowColor">
@@ -557,7 +557,7 @@ extends <a href="../../../../../noppes/npcs/scripted/interfaces/entity/IEntity.h
                      int&nbsp;duration,
                      int&nbsp;strength,
                      boolean&nbsp;hideParticles)</pre>
-<div class="block">Works the same as the <a href="http://minecraft.gamepedia.com/Commands#effect">/effect command</a></div>
+<div class="block">Works the same as the <a href="http://minecraft.wiki/w/Commands">/effect command</a></div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
 <dd><code>effect</code> - </dd>

--- a/docs/noppes/npcs/scripted/interfaces/entity/IPlayer.html
+++ b/docs/noppes/npcs/scripted/interfaces/entity/IPlayer.html
@@ -940,7 +940,7 @@ extends <a href="../../../../../noppes/npcs/scripted/interfaces/entity/IEntityLi
 <dt><span class="paramLabel">Parameters:</span></dt>
 <dd><code>message</code> - The message you want to send. Compatible with formatting codes, which can be found on the attached link.</dd>
 <dt><span class="seeLabel">See Also:</span></dt>
-<dd><a href="https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7e/Minecraft_Formatting.gif/revision/latest/scale-to-width-down/200?cb=20200828001454">Minecraft formatting codes</a></dd>
+<dd><a href="https://minecraft.wiki/images/Minecraft_Formatting.gif?2311f">Minecraft formatting codes</a></dd>
 </dl>
 </li>
 </ul>
@@ -1281,7 +1281,7 @@ extends <a href="../../../../../noppes/npcs/scripted/interfaces/entity/IEntityLi
 <pre>boolean&nbsp;hasAchievement(java.lang.String&nbsp;achievement)</pre>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
-<dd><code>achievement</code> - The achievement id. For a complete list see http://minecraft.gamepedia.com/Achievements</dd>
+<dd><code>achievement</code> - The achievement id. For a complete list see http://minecraft.wiki/w/Achievements</dd>
 <dt><span class="returnLabel">Returns:</span></dt>
 <dd>Returns whether or not the player has this achievement</dd>
 </dl>

--- a/src/main/java/noppes/npcs/scripted/ScriptWorld.java
+++ b/src/main/java/noppes/npcs/scripted/ScriptWorld.java
@@ -1125,7 +1125,7 @@ public class ScriptWorld implements IWorld {
 
 	/**
 	 * Sends a packet from the server to the client everytime its called. Probably should not use this too much.
-	 * @param particle Particle name. Particle name list: http://minecraft.gamepedia.com/Particles
+	 * @param particle Particle name. Particle name list: http://minecraft.wiki/w/Particles
 	 * @param x The x position
 	 * @param y The y position
 	 * @param z The z position

--- a/src/main/java/noppes/npcs/scripted/entity/ScriptLivingBase.java
+++ b/src/main/java/noppes/npcs/scripted/entity/ScriptLivingBase.java
@@ -237,7 +237,7 @@ public class ScriptLivingBase<T extends EntityLivingBase> extends ScriptEntity<T
 	}
 	
 	/**
-	 * Works the same as the <a href="http://minecraft.gamepedia.com/Commands#effect">/effect command</a>
+	 * Works the same as the <a href="http://minecraft.wiki/w/Commands">/effect command</a>
 	 * @param effect
 	 * @param duration The duration in seconds
 	 * @param strength The amplifier of the potion effect

--- a/src/main/java/noppes/npcs/scripted/entity/ScriptPlayer.java
+++ b/src/main/java/noppes/npcs/scripted/entity/ScriptPlayer.java
@@ -629,7 +629,7 @@ public class ScriptPlayer<T extends EntityPlayerMP> extends ScriptLivingBase<T> 
 	}
 
 	/**
-	 * @param achievement The achievement id. For a complete list see http://minecraft.gamepedia.com/Achievements
+	 * @param achievement The achievement id. For a complete list see http://minecraft.wiki/w/Achievements
 	 * @return Returns whether or not the player has this achievement
 	 */
 	public boolean hasAchievement(String achievement){

--- a/src/main/java/noppes/npcs/scripted/scoreboard/ScriptScoreboard.java
+++ b/src/main/java/noppes/npcs/scripted/scoreboard/ScriptScoreboard.java
@@ -63,7 +63,7 @@ public class ScriptScoreboard implements IScoreboard {
 	/**
 	 * @version 1.8
 	 * @param objective Scoreboard objective name (1-16 chars)
-	 * @param criteria The criteria see http://minecraft.gamepedia.com/Scoreboard#Objectives
+	 * @param criteria The criteria see http://minecraft.wiki/w/Scoreboard#Objectives
 	 * @return Returns the created ScoreboardObjective, returns null if it failed to create
 	 */
 	public IScoreboardObjective addObjective(String objective, String criteria){


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly.