### PR TITLE
Add manual quest type & objective command

### DIFF
--- a/src/main/java/kamkeel/command/CommandKamkeel.java
+++ b/src/main/java/kamkeel/command/CommandKamkeel.java
@@ -28,6 +28,7 @@ public class CommandKamkeel extends CommandBase{
 		registerCommand(new QuestCategoryCommand());
 		registerCommand(new DialogCommand());
 		registerCommand(new DialogCategoryCommand());
+		registerCommand(new ObjectiveCommand());
 		registerCommand(new FactionCommand());
 		registerCommand(new NpcCommand());
 		registerCommand(new CloneCommand());

--- a/src/main/java/kamkeel/command/ObjectiveCommand.java
+++ b/src/main/java/kamkeel/command/ObjectiveCommand.java
@@ -102,15 +102,13 @@ public class ObjectiveCommand extends CommandKamkeelBase {
 
         for(PlayerData playerdata : data) {
             QuestData questdata = playerdata.questData.activeQuests.get(questid);
-            if (questdata instanceof IQuestObjective) {
-                IQuestInterface iQuestInterface = questdata.quest.getQuestInterface();
-                if (iQuestInterface instanceof QuestInterface) {
-                    QuestInterface questInterface = (QuestInterface)iQuestInterface;
-                    IQuestObjective objective = questInterface.getObjectives((EntityPlayer)sender)[objectivenumber];
-                    changeMethod.apply(objective, progress);
-                    sendResult(sender, String.format("Objective current value for Quest \u00A7e%d\u00A77 for Player '\u00A7b%s\u00A77' is %d of %d" , questid, playerdata.playername, objectivenumber, objective.getProgress(), objective.getMaxProgress()));
-                    return;
-                }
+            IQuestInterface iQuestInterface = questdata.quest.getQuestInterface();
+            if (iQuestInterface instanceof QuestInterface) {
+                QuestInterface questInterface = (QuestInterface)iQuestInterface;
+                IQuestObjective objective = questInterface.getObjectives((EntityPlayer)sender)[objectivenumber];
+                changeMethod.apply(objective, progress);
+                sendResult(sender, String.format("Objective current value for Quest \u00A7e%d\u00A77 for Player '\u00A7b%s\u00A77' is %d of %d" , questid, playerdata.playername, objectivenumber, objective.getProgress(), objective.getMaxProgress()));
+                return;
             }
         }
             
@@ -157,14 +155,12 @@ public class ObjectiveCommand extends CommandKamkeelBase {
 
         for(PlayerData playerdata : data) {
             QuestData questdata = playerdata.questData.activeQuests.get(questid);
-            if (questdata instanceof IQuestObjective) {
-                IQuestInterface iQuestInterface = questdata.quest.getQuestInterface();
-                if (iQuestInterface instanceof QuestInterface) {
-                    QuestInterface questInterface = (QuestInterface)iQuestInterface;
-                    IQuestObjective objective = questInterface.getObjectives((EntityPlayer)sender)[objectivenumber];
-                    sendResult(sender, String.format("Objective current value for Quest \u00A7e%d\u00A77 for Player '\u00A7b%s\u00A77' is %d of %d" , questid, playerdata.playername, objectivenumber, objective.getProgress(), objective.getMaxProgress()));
-                    return;
-                }
+            IQuestInterface iQuestInterface = questdata.quest.getQuestInterface();
+            if (iQuestInterface instanceof QuestInterface) {
+                QuestInterface questInterface = (QuestInterface)iQuestInterface;
+                IQuestObjective objective = questInterface.getObjectives((EntityPlayer)sender)[objectivenumber];
+                sendResult(sender, String.format("Objective current value for Quest \u00A7e%d\u00A77 for Player '\u00A7b%s\u00A77' is %d of %d" , questid, playerdata.playername, objectivenumber, objective.getProgress(), objective.getMaxProgress()));
+                return;
             }
         }
             

--- a/src/main/java/kamkeel/command/ObjectiveCommand.java
+++ b/src/main/java/kamkeel/command/ObjectiveCommand.java
@@ -1,0 +1,173 @@
+package kamkeel.command;
+
+import java.util.List;
+
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import noppes.npcs.api.handler.data.IQuestInterface;
+import noppes.npcs.api.handler.data.IQuestObjective;
+import noppes.npcs.controllers.PlayerDataController;
+import noppes.npcs.controllers.QuestController;
+import noppes.npcs.controllers.data.PlayerData;
+import noppes.npcs.controllers.data.Quest;
+import noppes.npcs.controllers.data.QuestData;
+import noppes.npcs.quests.QuestInterface;
+
+public class ObjectiveCommand extends CommandKamkeelBase {
+
+    @FunctionalInterface
+    interface ProcessProgressChnageFunction {
+        public void apply(IQuestObjective objective, Integer progress);
+    }
+
+    @Override
+    public String getCommandName() {
+        return "objective";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Objective operations";
+    }
+
+    @SubCommand(
+        desc = "Sets a value for an objective",
+        usage = "<player> <quest> <objective> <value>"
+    )
+    public void set(ICommandSender sender, String[] args) throws CommandException {
+        processProgressChangeCommand(sender, args,
+            (objective, progress) -> objective.setProgress(progress));
+    }
+
+    @SubCommand(
+        desc = "Add a value for an objective to the existing value.",
+        usage = "<player> <quest> <objective> <value>"
+    )
+    public void add(ICommandSender sender, String[] args) throws CommandException {
+        processProgressChangeCommand(sender, args,
+            (objective, progress) -> objective.setProgress(objective.getProgress() + progress));
+    }
+
+    @SubCommand(
+        desc = "Substracts a value for an objective from its existing value.",
+        usage = "<player> <quest> <objective> <value>"
+    )
+    public void sub(ICommandSender sender, String[] args) throws CommandException {
+        processProgressChangeCommand(sender, args,
+            (objective, progress) -> objective.setProgress(objective.getProgress() - progress));
+    }
+
+    public void processProgressChangeCommand(ICommandSender sender, String[] args, ProcessProgressChnageFunction changeMethod) {
+        if (!(sender instanceof EntityPlayer)) {
+            return;
+        }
+        
+        String playername = args[0];
+        int questid;
+        try {
+            questid = Integer.parseInt(args[1]);
+        } catch (NumberFormatException ex) {
+            sendError(sender, "QuestID must be an integer: " + args[1]);
+            return;
+        }
+        
+        int objectivenumber;
+        try {
+            objectivenumber = Integer.parseInt(args[2]);
+        } catch (NumberFormatException ex) {
+            sendError(sender, "Objective must be an integer: " + args[2]);
+            return;
+        }
+        
+        int progress;
+        try {
+            progress = Integer.parseInt(args[3]);
+        } catch (NumberFormatException ex) {
+            sendError(sender, "Objective must be an integer: " + args[3]);
+            return;
+        }
+
+        List<PlayerData> data = PlayerDataController.Instance.getPlayersData(sender, playername);
+        if (data.isEmpty()) {
+            sendError(sender, "Unknown player: " + playername);
+            return;
+        }
+
+        Quest quest = QuestController.Instance.quests.get(questid);
+        if (quest == null) {
+        	sendError(sender, "Unknown QuestID: " + questid);
+            return;
+        }
+
+        for(PlayerData playerdata : data) {
+            QuestData questdata = playerdata.questData.activeQuests.get(questid);
+            if (questdata instanceof IQuestObjective) {
+                IQuestInterface iQuestInterface = questdata.quest.getQuestInterface();
+                if (iQuestInterface instanceof QuestInterface) {
+                    QuestInterface questInterface = (QuestInterface)iQuestInterface;
+                    IQuestObjective objective = questInterface.getObjectives((EntityPlayer)sender)[objectivenumber];
+                    changeMethod.apply(objective, progress);
+                    sendResult(sender, String.format("Objective current value for Quest \u00A7e%d\u00A77 for Player '\u00A7b%s\u00A77' is %d of %d" , questid, playerdata.playername, objectivenumber, objective.getProgress(), objective.getMaxProgress()));
+                    return;
+                }
+            }
+        }
+            
+        sendError(sender, "Quest is not objectivable: " + questid);
+    }
+
+    @SubCommand(
+        desc = "Gets the value of an objective",
+        usage = "<player> <quest> <objective>"
+    )
+    public void get(ICommandSender sender, String[] args) throws CommandException {
+        if (!(sender instanceof EntityPlayer)) {
+            return;
+        }
+        
+        String playername = args[0];
+        int questid;
+        try {
+            questid = Integer.parseInt(args[1]);
+        } catch (NumberFormatException ex) {
+            sendError(sender, "QuestID must be an integer: " + args[1]);
+            return;
+        }
+        
+        int objectivenumber;
+        try {
+            objectivenumber = Integer.parseInt(args[2]);
+        } catch (NumberFormatException ex) {
+            sendError(sender, "Objective must be an integer: " + args[2]);
+            return;
+        }
+
+        List<PlayerData> data = PlayerDataController.Instance.getPlayersData(sender, playername);
+        if (data.isEmpty()) {
+            sendError(sender, "Unknown player: " + playername);
+            return;
+        }
+
+        Quest quest = QuestController.Instance.quests.get(questid);
+        if (quest == null) {
+        	sendError(sender, "Unknown QuestID: " + questid);
+            return;
+        }
+
+        for(PlayerData playerdata : data) {
+            QuestData questdata = playerdata.questData.activeQuests.get(questid);
+            if (questdata instanceof IQuestObjective) {
+                IQuestInterface iQuestInterface = questdata.quest.getQuestInterface();
+                if (iQuestInterface instanceof QuestInterface) {
+                    QuestInterface questInterface = (QuestInterface)iQuestInterface;
+                    IQuestObjective objective = questInterface.getObjectives((EntityPlayer)sender)[objectivenumber];
+                    sendResult(sender, String.format("Objective current value for Quest \u00A7e%d\u00A77 for Player '\u00A7b%s\u00A77' is %d of %d" , questid, playerdata.playername, objectivenumber, objective.getProgress(), objective.getMaxProgress()));
+                    return;
+                }
+            }
+        }
+            
+        sendError(sender, "Quest is not objectivable: " + questid);
+    }
+}

--- a/src/main/java/noppes/npcs/client/gui/SubGuiNpcQuest.java
+++ b/src/main/java/noppes/npcs/client/gui/SubGuiNpcQuest.java
@@ -9,6 +9,7 @@ import noppes.npcs.client.gui.global.GuiNPCQuestSelection;
 import noppes.npcs.client.gui.questtypes.GuiNpcQuestTypeDialog;
 import noppes.npcs.client.gui.questtypes.GuiNpcQuestTypeKill;
 import noppes.npcs.client.gui.questtypes.GuiNpcQuestTypeLocation;
+import noppes.npcs.client.gui.questtypes.GuiNpcQuestTypeManual;
 import noppes.npcs.client.gui.util.*;
 import noppes.npcs.constants.*;
 import noppes.npcs.controllers.data.PlayerMail;
@@ -125,6 +126,9 @@ public class SubGuiNpcQuest extends SubGuiInterface implements ISubGuiListener, 
 
 			if(quest.type == EnumQuestType.AreaKill)
 				setSubGui(new GuiNpcQuestTypeKill(npc, quest, this));
+			
+			if(quest.type == EnumQuestType.Manual)
+				setSubGui(new GuiNpcQuestTypeManual(npc, quest, this));
 		}
 		if(button.id == 8)
 		{

--- a/src/main/java/noppes/npcs/client/gui/SubGuiNpcQuest.java
+++ b/src/main/java/noppes/npcs/client/gui/SubGuiNpcQuest.java
@@ -62,7 +62,7 @@ public class SubGuiNpcQuest extends SubGuiInterface implements ISubGuiListener, 
 		addButton(new GuiNpcButton(11, guiLeft + 303, guiTop + 52, 50, 20, "selectServer.edit"));
 
 		addLabel(new GuiNpcLabel(6, "gui.type", guiLeft + 180, guiTop + 81));
-		addButton(new GuiNpcButton(6, guiLeft + 240, guiTop + 76, 60, 20, new String[]{"quest.item","quest.dialog","quest.kill","quest.location","quest.areakill"},quest.type.ordinal()));
+		addButton(new GuiNpcButton(6, guiLeft + 240, guiTop + 76, 60, 20, new String[]{"quest.item","quest.dialog","quest.kill","quest.location","quest.areakill","quest.manual"},quest.type.ordinal()));
 		addButton(new GuiNpcButton(7, guiLeft + 303, guiTop + 76,50, 20, "selectServer.edit"));
 
 		addLabel(new GuiNpcLabel(17, "party.options", guiLeft + 180, guiTop + 135));

--- a/src/main/java/noppes/npcs/client/gui/questtypes/GuiNpcQuestTypeManual.java
+++ b/src/main/java/noppes/npcs/client/gui/questtypes/GuiNpcQuestTypeManual.java
@@ -1,0 +1,143 @@
+package noppes.npcs.client.gui.questtypes;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.entity.EntityList;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.world.World;
+import noppes.npcs.client.gui.util.GuiCustomScroll;
+import noppes.npcs.client.gui.util.GuiNpcButton;
+import noppes.npcs.client.gui.util.GuiNpcLabel;
+import noppes.npcs.client.gui.util.GuiNpcTextField;
+import noppes.npcs.client.gui.util.ICustomScrollListener;
+import noppes.npcs.client.gui.util.ITextfieldListener;
+import noppes.npcs.client.gui.util.SubGuiInterface;
+import noppes.npcs.controllers.data.Quest;
+import noppes.npcs.entity.EntityNPCInterface;
+import noppes.npcs.quests.QuestManual;
+
+public class GuiNpcQuestTypeManual extends SubGuiInterface implements ITextfieldListener, ICustomScrollListener
+{
+	private GuiScreen parent;
+	private GuiCustomScroll scroll;
+	private QuestManual quest;
+	private GuiNpcTextField lastSelected;
+
+    public GuiNpcQuestTypeManual(EntityNPCInterface npc, Quest q, GuiScreen parent) {
+    	this.npc = npc;
+    	this.parent = parent;
+    	title = "Quest Manual Setup";
+    	
+    	quest = (QuestManual) q.questInterface;
+
+		setBackground("largebg.png");
+		bgScale = 1.7F;
+		bgScaleX = 1.1F;
+
+		xSize = 300;
+		ySize = 300;
+		closeOnEsc = true;
+	}
+
+	public void initGui() {
+		super.initGui();
+
+		guiTop -= 20;
+
+		int i = 0;
+		addLabel(new GuiNpcLabel(0, "Type a name for each objective here and defined the amount requied to complete.", guiLeft + 4, guiTop + 20));
+		for (String name : quest.objectives.keySet()) {
+			this.addTextField(new GuiNpcTextField(i, this, fontRendererObj, guiLeft + 4, guiTop + 40 + i * 22, 180, 20, name));
+			this.addTextField(new GuiNpcTextField(i + 12, this, fontRendererObj, guiLeft + 186, guiTop + 40 + i * 22, 24, 20, quest.objectives.get(name) + ""));
+			this.getTextField(i+12).integersOnly = true;
+			this.getTextField(i+12).setMinMaxDefault(1, Integer.MAX_VALUE, 1);
+			i++;
+		}
+		
+		for(;i < 12; i++){
+			this.addTextField(new GuiNpcTextField(i, this, fontRendererObj, guiLeft + 4, guiTop + 40 + i * 22, 180, 20, ""));
+			this.addTextField(new GuiNpcTextField(i + 12, this, fontRendererObj, guiLeft + 186, guiTop + 40 + i * 22, 24, 20, "1"));
+			this.getTextField(i+12).integersOnly = true;
+			this.getTextField(i+12).setMinMaxDefault(1, Integer.MAX_VALUE, 1);
+		}
+        Map<?,?> data = EntityList.stringToClassMapping;
+        ArrayList<String> list = new ArrayList<String>();
+        for(Object name : data.keySet()){
+        	Class<?> c = (Class<?>) data.get(name);
+        	try {
+        		if(EntityLivingBase.class.isAssignableFrom(c) && !EntityNPCInterface.class.isAssignableFrom(c) && c.getConstructor(new Class[] {World.class}) != null && !Modifier.isAbstract(c.getModifiers()))
+        				list.add(name.toString());
+			} catch (SecurityException e) {
+				e.printStackTrace();
+			} catch (NoSuchMethodException e) {
+			}
+        }   
+        if(scroll == null)
+        	scroll = new GuiCustomScroll(this,0);
+        scroll.setList(list);
+        scroll.setSize(130, 198);
+        scroll.guiLeft = guiLeft + 220;
+        scroll.guiTop = guiTop + 40;
+        addScroll(scroll);
+
+		guiTop += 50;
+		this.addButton(new GuiNpcButton(0, guiLeft + 4, guiTop + 310, 98, 20, "gui.back"));
+		this.getTextField(36).setVisible(this.getButton(1).getValue() == 2);
+
+		guiTop -= 50;
+
+    	scroll.visible = GuiNpcTextField.isFieldActive();
+	}
+
+	protected void actionPerformed(GuiButton guibutton) {
+		super.actionPerformed(guibutton);
+		if (guibutton.id == 0) {
+			close();
+		}
+	}
+    public void mouseClicked(int i, int j, int k)
+    {
+    	super.mouseClicked(i, j, k);
+    	scroll.visible = GuiNpcTextField.isFieldActive();
+    }
+
+	public void save() {
+	}
+
+	@Override
+	public void unFocused(GuiNpcTextField guiNpcTextField) {
+		if(guiNpcTextField.id < 12) {
+            lastSelected = guiNpcTextField;
+        }
+        
+        saveObjectives();
+	}
+	private void saveObjectives(){
+		HashMap<String,Integer> map = new HashMap<String,Integer>();
+        
+		for(int i = 0; i< 12; i++){
+			String name = getTextField(i).getText();
+			
+            if(name.isEmpty()) {
+                continue;
+            }
+
+			map.put(name, getTextField(i+12).getInteger());
+		}
+
+		quest.objectives = map;
+	}
+	@Override
+	public void customScrollClicked(int i, int j, int k, GuiCustomScroll guiCustomScroll) {
+		if(lastSelected == null) {
+            return;
+        }
+		lastSelected.setText(guiCustomScroll.getSelected());
+		saveObjectives();
+	}
+}

--- a/src/main/java/noppes/npcs/client/gui/questtypes/GuiNpcQuestTypeManual.java
+++ b/src/main/java/noppes/npcs/client/gui/questtypes/GuiNpcQuestTypeManual.java
@@ -1,38 +1,25 @@
 package noppes.npcs.client.gui.questtypes;
 
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map;
 
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.entity.EntityList;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.world.World;
-import noppes.npcs.client.gui.util.GuiCustomScroll;
 import noppes.npcs.client.gui.util.GuiNpcButton;
 import noppes.npcs.client.gui.util.GuiNpcLabel;
 import noppes.npcs.client.gui.util.GuiNpcTextField;
-import noppes.npcs.client.gui.util.ICustomScrollListener;
 import noppes.npcs.client.gui.util.ITextfieldListener;
 import noppes.npcs.client.gui.util.SubGuiInterface;
 import noppes.npcs.controllers.data.Quest;
 import noppes.npcs.entity.EntityNPCInterface;
 import noppes.npcs.quests.QuestManual;
 
-public class GuiNpcQuestTypeManual extends SubGuiInterface implements ITextfieldListener, ICustomScrollListener
+public class GuiNpcQuestTypeManual extends SubGuiInterface implements ITextfieldListener
 {
-	private GuiScreen parent;
-	private GuiCustomScroll scroll;
 	private QuestManual quest;
-	private GuiNpcTextField lastSelected;
 
     public GuiNpcQuestTypeManual(EntityNPCInterface npc, Quest q, GuiScreen parent) {
     	this.npc = npc;
-    	this.parent = parent;
     	title = "Quest Manual Setup";
-    	
     	quest = (QuestManual) q.questInterface;
 
 		setBackground("largebg.png");
@@ -47,10 +34,11 @@ public class GuiNpcQuestTypeManual extends SubGuiInterface implements ITextfield
 	public void initGui() {
 		super.initGui();
 
+		int i = 0;
 		guiTop -= 20;
 
-		int i = 0;
 		addLabel(new GuiNpcLabel(0, "Type a name for each objective here and defined the amount requied to complete.", guiLeft + 4, guiTop + 20));
+
 		for (String name : quest.objectives.keySet()) {
 			this.addTextField(new GuiNpcTextField(i, this, fontRendererObj, guiLeft + 4, guiTop + 40 + i * 22, 180, 20, name));
 			this.addTextField(new GuiNpcTextField(i + 12, this, fontRendererObj, guiLeft + 186, guiTop + 40 + i * 22, 24, 20, quest.objectives.get(name) + ""));
@@ -65,33 +53,11 @@ public class GuiNpcQuestTypeManual extends SubGuiInterface implements ITextfield
 			this.getTextField(i+12).integersOnly = true;
 			this.getTextField(i+12).setMinMaxDefault(1, Integer.MAX_VALUE, 1);
 		}
-        Map<?,?> data = EntityList.stringToClassMapping;
-        ArrayList<String> list = new ArrayList<String>();
-        for(Object name : data.keySet()){
-        	Class<?> c = (Class<?>) data.get(name);
-        	try {
-        		if(EntityLivingBase.class.isAssignableFrom(c) && !EntityNPCInterface.class.isAssignableFrom(c) && c.getConstructor(new Class[] {World.class}) != null && !Modifier.isAbstract(c.getModifiers()))
-        				list.add(name.toString());
-			} catch (SecurityException e) {
-				e.printStackTrace();
-			} catch (NoSuchMethodException e) {
-			}
-        }   
-        if(scroll == null)
-        	scroll = new GuiCustomScroll(this,0);
-        scroll.setList(list);
-        scroll.setSize(130, 198);
-        scroll.guiLeft = guiLeft + 220;
-        scroll.guiTop = guiTop + 40;
-        addScroll(scroll);
 
 		guiTop += 50;
 		this.addButton(new GuiNpcButton(0, guiLeft + 4, guiTop + 310, 98, 20, "gui.back"));
-		this.getTextField(36).setVisible(this.getButton(1).getValue() == 2);
 
 		guiTop -= 50;
-
-    	scroll.visible = GuiNpcTextField.isFieldActive();
 	}
 
 	protected void actionPerformed(GuiButton guibutton) {
@@ -103,20 +69,13 @@ public class GuiNpcQuestTypeManual extends SubGuiInterface implements ITextfield
     public void mouseClicked(int i, int j, int k)
     {
     	super.mouseClicked(i, j, k);
-    	scroll.visible = GuiNpcTextField.isFieldActive();
     }
-
-	public void save() {
-	}
 
 	@Override
 	public void unFocused(GuiNpcTextField guiNpcTextField) {
-		if(guiNpcTextField.id < 12) {
-            lastSelected = guiNpcTextField;
-        }
-        
         saveObjectives();
 	}
+
 	private void saveObjectives(){
 		HashMap<String,Integer> map = new HashMap<String,Integer>();
         
@@ -131,13 +90,5 @@ public class GuiNpcQuestTypeManual extends SubGuiInterface implements ITextfield
 		}
 
 		quest.objectives = map;
-	}
-	@Override
-	public void customScrollClicked(int i, int j, int k, GuiCustomScroll guiCustomScroll) {
-		if(lastSelected == null) {
-            return;
-        }
-		lastSelected.setText(guiCustomScroll.getSelected());
-		saveObjectives();
 	}
 }

--- a/src/main/java/noppes/npcs/constants/EnumQuestType.java
+++ b/src/main/java/noppes/npcs/constants/EnumQuestType.java
@@ -1,5 +1,5 @@
 package noppes.npcs.constants;
 
 public enum EnumQuestType {
-	Item, Dialog, Kill, Location, AreaKill;
+	Item, Dialog, Kill, Location, AreaKill, Manual;
 }

--- a/src/main/java/noppes/npcs/controllers/data/Quest.java
+++ b/src/main/java/noppes/npcs/controllers/data/Quest.java
@@ -87,6 +87,8 @@ public class Quest implements ICompatibilty, IQuest {
 			questInterface = new QuestKill();
 		else if(type == EnumQuestType.Location)
 			questInterface = new QuestLocation();
+		else if(type == EnumQuestType.Manual)
+			questInterface = new QuestManual();
 
 		if(questInterface != null)
 			questInterface.questId = id;

--- a/src/main/java/noppes/npcs/quests/QuestManual.java
+++ b/src/main/java/noppes/npcs/quests/QuestManual.java
@@ -19,9 +19,9 @@ import noppes.npcs.scripted.CustomNPCsException;
 
 public class QuestManual extends QuestInterface {
 
-    public static final String NBT_KEY_OBJECTIVE = "QuestManual";
-    public static final String DATA_KEY_OBJECTIVE_FOUND = "QuestManualFound";
-    public static final Integer OBJECTIVES_COUNT = 5;
+    public static final String NBT_KEY_OBJECTIVE = "QuestManuals";
+    public static final String DATA_KEY_OBJECTIVE_FOUND = "QuestManualsFound";
+    public static final Integer OBJECTIVES_COUNT = 10;
     
     public HashMap<String, Integer> objectives = new HashMap<String, Integer>();
 
@@ -32,9 +32,10 @@ public class QuestManual extends QuestInterface {
 
     @Override
     public void readEntityFromNBT(NBTTagCompound compound) {
-        objectives.clear();
         if (compound.hasKey(NBT_KEY_OBJECTIVE)) {
-            objectives.putAll(NBTTags.getStringIntegerMap(compound.getTagList(NBT_KEY_OBJECTIVE, 5)));
+            objectives = NBTTags.getStringIntegerMap(compound.getTagList(NBT_KEY_OBJECTIVE, OBJECTIVES_COUNT));
+        } else {
+            objectives.clear();
         }
     }
 
@@ -64,14 +65,18 @@ public class QuestManual extends QuestInterface {
 		Vector<String> vec = new Vector<String>();
 		PlayerQuestData playerdata = PlayerDataController.Instance.getPlayerData(player).questData;
 		QuestData data = playerdata.activeQuests.get(questId);
+
 		if(data == null)
 			return vec;
+
 		HashMap<String,Integer> found = getFound(data);
+
 		for(String entityName : objectives.keySet()){
-			//Class cls = (Class) EntityList.stringToClassMapping.get(entityName);
 			int amount = 0;
+
 			if(found.containsKey(entityName))
 				amount = found.get(entityName);
+
 			String state = amount + "/" + objectives.get(entityName);
 			
 			vec.add(entityName + ": " + state);

--- a/src/main/java/noppes/npcs/quests/QuestManual.java
+++ b/src/main/java/noppes/npcs/quests/QuestManual.java
@@ -1,0 +1,167 @@
+package noppes.npcs.quests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import noppes.npcs.NBTTags;
+import noppes.npcs.api.handler.data.IQuestObjective;
+import noppes.npcs.constants.EnumQuestType;
+import noppes.npcs.controllers.PlayerDataController;
+import noppes.npcs.controllers.data.PlayerData;
+import noppes.npcs.controllers.data.PlayerQuestData;
+import noppes.npcs.controllers.data.QuestData;
+import noppes.npcs.scripted.CustomNPCsException;
+
+public class QuestManual extends QuestInterface {
+
+    public static final String NBT_KEY_OBJECTIVE = "QuestManual";
+    public static final String DATA_KEY_OBJECTIVE_FOUND = "QuestManualFound";
+    public static final Integer OBJECTIVES_COUNT = 5;
+    
+    public HashMap<String, Integer> objectives = new HashMap<String, Integer>();
+
+    @Override
+    public void writeEntityToNBT(NBTTagCompound compound) {
+        compound.setTag(NBT_KEY_OBJECTIVE, NBTTags.nbtStringIntegerMap(objectives));
+    }
+
+    @Override
+    public void readEntityFromNBT(NBTTagCompound compound) {
+        objectives.clear();
+        if (compound.hasKey(NBT_KEY_OBJECTIVE)) {
+            objectives.putAll(NBTTags.getStringIntegerMap(compound.getTagList(NBT_KEY_OBJECTIVE, 5)));
+        }
+    }
+
+    @Override
+    public boolean isCompleted(PlayerData player) {
+        QuestData data = player.questData.activeQuests.get(questId);
+
+        if (data == null) {
+            return false;
+        }
+
+        HashMap<String, Integer> found = getFound(data);
+
+        for (String objectiveName : objectives.keySet()) {
+            int amount = 0;
+            if (found.containsKey(objectiveName))
+                amount = found.get(objectiveName);
+            if (amount < objectives.get(objectiveName))
+                return false;
+        }
+
+        return true;
+    }
+
+	@Override
+	public Vector<String> getQuestLogStatus(EntityPlayer player) {
+		Vector<String> vec = new Vector<String>();
+		PlayerQuestData playerdata = PlayerDataController.Instance.getPlayerData(player).questData;
+		QuestData data = playerdata.activeQuests.get(questId);
+		if(data == null)
+			return vec;
+		HashMap<String,Integer> found = getFound(data);
+		for(String entityName : objectives.keySet()){
+			//Class cls = (Class) EntityList.stringToClassMapping.get(entityName);
+			int amount = 0;
+			if(found.containsKey(entityName))
+				amount = found.get(entityName);
+			String state = amount + "/" + objectives.get(entityName);
+			
+			vec.add(entityName + ": " + state);
+		}
+		
+		return vec;
+	}
+
+    @Override
+    public IQuestObjective[] getObjectives(EntityPlayer player) {
+		List<IQuestObjective> list = new ArrayList<IQuestObjective>();
+
+        for (Map.Entry<String, Integer> entry : objectives.entrySet()) {
+            list.add(new noppes.npcs.quests.QuestManual.QuestManualObjective(this, player, entry.getKey(), entry.getValue()));
+        }
+
+		return (IQuestObjective[])list.toArray(new IQuestObjective[list.size()]);
+    }
+
+    public HashMap<String, Integer> getFound(QuestData data) {
+        return NBTTags.getStringIntegerMap(data.extraData.getTagList(DATA_KEY_OBJECTIVE_FOUND, 10));
+    }
+
+    public void setFound(QuestData data, HashMap<String, Integer> found) {
+        data.extraData.setTag(DATA_KEY_OBJECTIVE_FOUND, NBTTags.nbtStringIntegerMap(found));
+    }
+
+    class QuestManualObjective implements IQuestObjective {
+        private final QuestManual parent;
+        private final EntityPlayer player;
+        private final String objective;
+        private final int amount;
+
+        public QuestManualObjective(QuestManual parent, EntityPlayer player, String objective, int amount) {
+            this.parent = parent;
+            this.player = player;
+            this.objective = objective;
+            this.amount = amount;
+        }
+
+        @Override
+        public int getProgress() {
+			PlayerData data = PlayerDataController.Instance.getPlayerData(player);
+			PlayerQuestData playerdata = data.questData;
+			QuestData questdata = (QuestData)playerdata.activeQuests.get(parent.questId);
+
+			if(questdata != null) {
+				HashMap<String, Integer> found = parent.getFound(questdata);
+                String key = QuestManual.DATA_KEY_OBJECTIVE_FOUND + objective;
+				return !found.containsKey(key) ? 0 : (Integer)found.get(key);
+			}
+
+			return 0;
+        }
+
+        @Override
+        public void setProgress(int progress) {
+			if (progress >= 0 && progress <= this.amount) {
+				PlayerData data = PlayerDataController.Instance.getPlayerData(player);
+				PlayerQuestData playerdata = data.questData;
+				QuestData questdata = (QuestData)playerdata.activeQuests.get(this.parent.questId);
+				if(questdata != null){
+					HashMap<String, Integer> found = this.parent.getFound(questdata);
+                    
+					if (!found.containsKey(this.objective) || (Integer)found.get(this.objective) != progress) {
+						found.put(this.objective, progress);
+						this.parent.setFound(questdata, found);
+						data.questData.checkQuestCompletion(data, EnumQuestType.Manual);
+						data.save();
+					}
+				}
+			} else {
+				throw new CustomNPCsException("Progress has to be between 0 and " + this.amount, new Object[0]);
+			}
+        }
+
+        @Override
+        public int getMaxProgress() {
+            return this.amount;
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return this.getProgress() >= this.amount;
+        }
+
+        @Override
+        public String getText() {
+            // TODO: Show the objective name instead of the number!
+            return this.objective + ": " + this.getProgress() + "/" + this.getMaxProgress();
+        }
+    }
+}

--- a/src/main/java/noppes/npcs/quests/QuestManual.java
+++ b/src/main/java/noppes/npcs/quests/QuestManual.java
@@ -125,8 +125,7 @@ public class QuestManual extends QuestInterface {
 
 			if(questdata != null) {
 				HashMap<String, Integer> found = parent.getFound(questdata);
-                String key = QuestManual.DATA_KEY_OBJECTIVE_FOUND + objective;
-				return !found.containsKey(key) ? 0 : (Integer)found.get(key);
+				return !found.containsKey(objective) ? 0 : (Integer)found.get(objective);
 			}
 
 			return 0;

--- a/src/main/resources/assets/customnpcs/lang/de_DE.lang
+++ b/src/main/resources/assets/customnpcs/lang/de_DE.lang
@@ -403,6 +403,7 @@ quest.item=Item
 quest.kill=Tötungs Quest
 quest.areakill=Bereich Tötungs Quest
 quest.dialog=Dialog
+quest.manual=Manuell
 quest.location=Location
 quest.completedtext=Abgeschlossener Text
 quest.questlogtext=Questlog text

--- a/src/main/resources/assets/customnpcs/lang/en_US.lang
+++ b/src/main/resources/assets/customnpcs/lang/en_US.lang
@@ -549,6 +549,7 @@ quest.item=Item
 quest.kill=Kill
 quest.areakill=AreaKill
 quest.dialog=Dialog
+quest.manual=Manual
 quest.location=Location
 quest.completedtext=Completed text
 quest.questlogtext=Questlog text


### PR DESCRIPTION
A manual quest type like in newer versions.

### Features
- You can set objectives (up to 10)
- You can complete the objectives with scripting or using a command

### Commands

- `/noppes objective get <player> <quest> <objective>`
  - Gets the state of an objective.
  - `player`: The target playername
  - `quest`: The quest id of the active quest
  - `objective`: The objective's index
- `/noppes objective set <player> <quest> <objective> <value>`
  - Sets an value for the of an objective.
  - `player`: The target playername
  - `quest`: The quest id of the active quest
  - `objective`: The objective's index
  - `value`: The value to set for the objective
- `/noppes objective add <player> <quest> <objective> <value>`
  - Adds an value to a current objective value.
  - `player`: The target playername
  - `quest`: The quest id of the active quest
  - `objective`: The objective's index
  - `value`: The value to add to the current objective value
- `/noppes objective sub <player> <quest> <objective> <value>`
  - Substracts an value from a current objective value.
  - `player`: The target playername
  - `quest`: The quest id of the active quest
  - `objective`: The objective's index
  - `value`: The value to substract from the current objective value