### PR TITLE
add check FakePlayers

### DIFF
--- a/src/main/java/noppes/npcs/controllers/data/PlayerQuestData.java
+++ b/src/main/java/noppes/npcs/controllers/data/PlayerQuestData.java
@@ -1,5 +1,6 @@
 package noppes.npcs.controllers.data;
 
+import net.minecraftforge.common.util.FakePlayer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
@@ -115,6 +116,9 @@ public class PlayerQuestData implements IPlayerQuestData {
 	public boolean checkQuestCompletion(PlayerData playerData,EnumQuestType type) {
 		boolean bo = false;
 		EntityPlayer player = playerData.player;
+
+		if (player instanceof FakePlayer)
+			return false;
 
 		ArrayList<QuestData> activeQuestValues = new ArrayList<>(this.activeQuests.values());
 		for(QuestData data : activeQuestValues){


### PR DESCRIPTION
when sending a packet to a fakeplayer (in my case a robot from opencomputers), an error is thrown in the console. i don't think they need to send packets to update quests i didn't understand under what circumstances the robot called the event, but the main thing is that this check fixed it