### PR TITLE
Send full Party NBT on updates

### DIFF
--- a/src/main/java/kamkeel/npcs/controllers/SyncController.java
+++ b/src/main/java/kamkeel/npcs/controllers/SyncController.java
@@ -9,6 +9,7 @@ import kamkeel.npcs.network.enums.EnumSyncType;
 import kamkeel.npcs.network.packets.data.LoginPacket;
 import kamkeel.npcs.network.packets.data.large.SyncEffectPacket;
 import kamkeel.npcs.network.packets.data.large.SyncPacket;
+import kamkeel.npcs.network.packets.request.party.PartyInfoPacket;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
@@ -97,6 +98,9 @@ public class SyncController {
 
         DBCAddon.instance.syncPlayer(player);
         syncPlayerData(player, false);
+
+        // Send party information to the player on login
+        PartyInfoPacket.sendPartyData(player);
     }
 
     public static NBTTagCompound workbenchNBT() {

--- a/src/main/java/kamkeel/npcs/network/packets/request/party/PartySavePacket.java
+++ b/src/main/java/kamkeel/npcs/network/packets/request/party/PartySavePacket.java
@@ -51,6 +51,7 @@ public final class PartySavePacket extends AbstractPacket {
         if (playerData.partyUUID != null) {
             Party party = PartyController.Instance().getParty(playerData.partyUUID);
             party.readClientNBT(ByteBufUtils.readNBT(in));
+            PartyController.Instance().pingPartyUpdate(party);
         }
     }
 }


### PR DESCRIPTION
## Summary
- send party information to players when they log in
- push a full party update to all members when a party is saved

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*
- `./gradlew test --offline` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685a710a68ac83238613d2dae45cafb4