### PR TITLE
Add config to clear Action Manager on death

### DIFF
--- a/src/main/java/noppes/npcs/ScriptPlayerEventHandler.java
+++ b/src/main/java/noppes/npcs/ScriptPlayerEventHandler.java
@@ -32,6 +32,7 @@ import noppes.npcs.controllers.CustomEffectController;
 import noppes.npcs.controllers.PartyController;
 import noppes.npcs.controllers.PlayerDataController;
 import noppes.npcs.controllers.ScriptController;
+import noppes.npcs.config.ConfigScript;
 import noppes.npcs.controllers.data.*;
 import noppes.npcs.entity.EntityNPCInterface;
 import noppes.npcs.items.ItemNpcTool;
@@ -496,7 +497,8 @@ public class ScriptPlayerEventHandler {
 
                 EntityPlayer player = (EntityPlayer) event.entityLiving;
                 PlayerData playerData = PlayerData.get(player);
-               // playerData.actionManager.clear();
+                if (ConfigScript.ClearActionsOnDeath)
+                    playerData.actionManager.clear();
             }
 
             if (event.source.getEntity() instanceof EntityPlayerMP) {

--- a/src/main/java/noppes/npcs/config/ConfigScript.java
+++ b/src/main/java/noppes/npcs/config/ConfigScript.java
@@ -63,6 +63,9 @@ public class ConfigScript {
 
     public static int ActionManagerTickDefault = 5;
 
+    public static Property ClearActionsOnDeathProperty;
+    public static boolean ClearActionsOnDeath = true;
+
     public static boolean IndividualPlayerScripts = false;
 
     public static void init(File configFile) {
@@ -125,6 +128,8 @@ public class ConfigScript {
 
             IndividualPlayerScripts = config.get(CUSTOMIZATION, "Individual Player Scripts", false, "Acts similar to CNPC 1.12 where Player Scripts like Init are run PER Player").getBoolean(false);
             ActionManagerTickDefault = config.get(CUSTOMIZATION, "Action Manager Tick Default", ActionManagerTickDefault, "How frequent to update the action manager ticking tasks").getInt(ActionManagerTickDefault);
+            ClearActionsOnDeathProperty = config.get(CUSTOMIZATION, "Clear Actions On Death", true, "If true, clears the Action Manager for players and NPCs when they die");
+            ClearActionsOnDeath = ClearActionsOnDeathProperty.getBoolean(true);
 
             // Convert to Legacy
             if (CustomNpcs.legacyExist) {

--- a/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
+++ b/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
@@ -66,6 +66,7 @@ import noppes.npcs.api.handler.data.ILine;
 import noppes.npcs.api.item.IItemStack;
 import noppes.npcs.client.EntityUtil;
 import noppes.npcs.config.ConfigMain;
+import noppes.npcs.config.ConfigScript;
 import noppes.npcs.constants.*;
 import noppes.npcs.controllers.FactionController;
 import noppes.npcs.controllers.LinkedNpcController;
@@ -1168,7 +1169,8 @@ public abstract class EntityNPCInterface extends EntityCreature implements IEnti
         setHealth(getMaxHealth());
         dataWatcher.updateObject(14, 0); // animation Normal
         dataWatcher.updateObject(15, 0);
-       // actionManager.clear();
+        if (ConfigScript.ClearActionsOnDeath)
+            actionManager.clear();
         combatHandler.reset();
         this.setAttackTarget(null);
         this.setRevengeTarget(null);


### PR DESCRIPTION
## Summary
- add a new `ClearActionsOnDeath` option in script config
- clear ActionManager for players and NPCs when they die if enabled

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686187108d208323ad22f51857d6f2c2