### PR TITLE
Ensure dialog close event is always fired

### DIFF
--- a/src/main/java/noppes/npcs/client/gui/player/modern/GuiModernDialogInteract.java
+++ b/src/main/java/noppes/npcs/client/gui/player/modern/GuiModernDialogInteract.java
@@ -57,6 +57,12 @@ public class GuiModernDialogInteract extends GuiNPCInterface implements IGuiClos
 
     private final HashMap<Integer, GuiDialogImage> dialogImages = new HashMap<>();
 
+    /**
+     * Similar to {@link noppes.npcs.client.gui.player.GuiDialogInteract#sentClosePacket} this flag
+     * tracks if a close packet was already sent to the server.
+     */
+    private boolean sentClosePacket = false;
+
     public GuiModernDialogInteract(EntityNPCInterface npc, Dialog dialog) {
         super(npc);
         this.dialog = dialog;
@@ -357,6 +363,7 @@ public class GuiModernDialogInteract extends GuiNPCInterface implements IGuiClos
     }
 
     private void closed() {
+        sentClosePacket = true;
         grabMouse(false);
         PacketClient.sendClient(new CheckPlayerValue(CheckPlayerValue.Type.CheckQuestCompletion));
     }
@@ -367,6 +374,7 @@ public class GuiModernDialogInteract extends GuiNPCInterface implements IGuiClos
 
     public void appendDialog(Dialog dialog) {
         closeOnEsc = !dialog.disableEsc;
+        sentClosePacket = false;
         this.dialogImages.clear();
         this.dialog = dialog;
         this.options = new ArrayList<Integer>();
@@ -422,5 +430,16 @@ public class GuiModernDialogInteract extends GuiNPCInterface implements IGuiClos
     @Override
     public void setClose(int i, NBTTagCompound data) {
         grabMouse(false);
+    }
+
+    @Override
+    public void onGuiClosed() {
+        if (!sentClosePacket) {
+            if (dialog != null) {
+                PacketClient.sendClient(new DialogSelectPacket(dialog.id, -1));
+            }
+            closed();
+        }
+        super.onGuiClosed();
     }
 }

--- a/src/main/java/noppes/npcs/client/gui/player/modern/GuiModernQuestDialog.java
+++ b/src/main/java/noppes/npcs/client/gui/player/modern/GuiModernQuestDialog.java
@@ -54,6 +54,11 @@ public class GuiModernQuestDialog extends GuiNPCInterface implements IGuiClose {
 
     private boolean isGrabbed = false;
 
+    /**
+     * Flag to ensure the dialog close packet is only sent once.
+     */
+    private boolean sentClosePacket = false;
+
     private final HashMap<Integer, GuiDialogImage> dialogImages = new HashMap<>();
     private Dialog prevDialog;
     private int optionId;
@@ -70,6 +75,7 @@ public class GuiModernQuestDialog extends GuiNPCInterface implements IGuiClose {
     public void initGui() {
         super.initGui();
         isGrabbed = false;
+        sentClosePacket = false;
         guiTop = (height - ySize);
         calculateRowHeight();
         this.scaledResolution = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
@@ -353,6 +359,7 @@ public class GuiModernQuestDialog extends GuiNPCInterface implements IGuiClose {
     }
 
     private void closed() {
+        sentClosePacket = true;
         grabMouse(false);
         PacketClient.sendClient(new CheckPlayerValue(CheckPlayerValue.Type.CheckQuestCompletion));
     }
@@ -402,5 +409,16 @@ public class GuiModernQuestDialog extends GuiNPCInterface implements IGuiClose {
     @Override
     public void setClose(int i, NBTTagCompound data) {
         grabMouse(false);
+    }
+
+    @Override
+    public void onGuiClosed() {
+        if (!sentClosePacket) {
+            if (prevDialog != null) {
+                PacketClient.sendClient(new DialogSelectPacket(prevDialog.id, -1));
+            }
+            closed();
+        }
+        super.onGuiClosed();
     }
 }


### PR DESCRIPTION
## Summary
- track if dialog close packets have already been sent
- send a close packet during `onGuiClosed` if the gui was closed externally
- reset the flag whenever new dialog data is appended
- check dialog references before sending the packet

## Testing
- `./gradlew --version` *(fails: unable to download gradle)*

------
https://chatgpt.com/codex/tasks/task_e_685a7f24910c83238d346eeb2ca970d8