### PR TITLE
Fix trader GUI after death

### DIFF
--- a/src/main/java/noppes/npcs/ServerEventsHandler.java
+++ b/src/main/java/noppes/npcs/ServerEventsHandler.java
@@ -285,6 +285,16 @@ public class ServerEventsHandler {
         }
     }
 
+    @SubscribeEvent
+    public void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event) {
+        if (event.player == null || event.player.worldObj == null || event.player.worldObj.isRemote)
+            return;
+
+        PlayerData data = PlayerData.get(event.player);
+        data.setGUIOpen(false);
+        data.editingNpc = null;
+    }
+
     private void doExcalibur(EntityPlayer player, EntityLivingBase entity) {
         ItemStack item = player.getCurrentEquippedItem();
         if (item == null || item.getItem() != CustomItems.excalibur)


### PR DESCRIPTION
## Summary
- clear trader GUI state on respawn so player can interact after dying

## Testing
- `./gradlew tasks --all` *(fails: unable to download gradle)*

------
https://chatgpt.com/codex/tasks/task_e_686b8ec0e32483239ef30dadc682651c