### PR TITLE
Fix soulbind apply logic

### DIFF
--- a/src/main/java/kamkeel/npcs/controllers/data/attribute/requirement/types/SoulbindRequirement.java
+++ b/src/main/java/kamkeel/npcs/controllers/data/attribute/requirement/types/SoulbindRequirement.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import kamkeel.npcs.controllers.data.attribute.requirement.IRequirementChecker;
+import kamkeel.npcs.controllers.ProfileController;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 
@@ -83,7 +84,25 @@ public class SoulbindRequirement implements IRequirementChecker {
     @Override
     public void apply(NBTTagCompound nbt, Object value) {
         if (value instanceof String) {
-            nbt.setString(getKey(), (String) value);
+            String entry = (String) value;
+            if (entry.isEmpty())
+                return;
+
+            // Check if the provided value is already a valid UUID
+            UUID uuid = null;
+            try {
+                uuid = UUID.fromString(entry);
+            } catch (Exception ignored) {
+            }
+
+            // If not a UUID, attempt to treat the value as a username
+            if (uuid == null) {
+                uuid = ProfileController.Instance.getUUIDFromUsername(entry);
+            }
+
+            if (uuid != null) {
+                nbt.setString(getKey(), uuid.toString());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- fix Soulbind requirement so usernames get resolved to UUID

## Testing
- `./gradlew --version` *(fails: HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686c2174016883239b84ff7ff7c95662