### PR TITLE
Fix recipe pre-event duplication bug

### DIFF
--- a/src/main/java/noppes/npcs/containers/ContainerAnvilRepair.java
+++ b/src/main/java/noppes/npcs/containers/ContainerAnvilRepair.java
@@ -217,6 +217,10 @@ public class ContainerAnvilRepair extends Container {
             ItemStack stack = slot.getStack();
             copy = stack.copy();
             if (index == 0) { // output slot
+                SlotAnvilOutput resultSlot = (SlotAnvilOutput) slot;
+                if (!resultSlot.preEvent(player)) {
+                    return null;
+                }
                 if (player.experienceTotal < this.repairCost) {
                     return null;
                 }
@@ -259,10 +263,30 @@ public class ContainerAnvilRepair extends Container {
     // subtracts one from the damaged item stack.
     public class SlotAnvilOutput extends Slot {
         private final ContainerAnvilRepair container;
+        private boolean preChecked = false;
+        private boolean canPickup = true;
 
         public SlotAnvilOutput(ContainerAnvilRepair container, IInventory inventory, int index, int x, int y) {
             super(inventory, index, x, y);
             this.container = container;
+        }
+
+        public boolean preEvent(EntityPlayer player) {
+            preChecked = true;
+            RecipeAnvil recipe = container.currentRecipe;
+            if (recipe != null) {
+                ItemStack[] items = new ItemStack[]{
+                    container.anvilMatrix.getStackInRowAndColumn(0, 0),
+                    container.anvilMatrix.getStackInRowAndColumn(1, 0)
+                };
+                canPickup = !EventHooks.onRecipeScriptPre(player, recipe.getScriptHandler(), recipe, items);
+                if (!canPickup) {
+                    container.updateRepairResult();
+                }
+            } else {
+                canPickup = true;
+            }
+            return canPickup;
         }
 
         @Override
@@ -272,20 +296,27 @@ public class ContainerAnvilRepair extends Container {
 
         @Override
         public boolean canTakeStack(EntityPlayer player) {
-            return player.experienceTotal >= container.repairCost;
+            if (!preChecked) {
+                preEvent(player);
+            }
+            return canPickup && player.experienceTotal >= container.repairCost;
         }
 
         @Override
         public void onPickupFromSlot(EntityPlayer player, ItemStack stack) {
+            if (!preChecked) {
+                if (!preEvent(player))
+                    return;
+            }
+            if (!canPickup) {
+                return;
+            }
             RecipeAnvil recipe = container.currentRecipe;
             ItemStack[] items = new ItemStack[]{
                 container.anvilMatrix.getStackInRowAndColumn(0, 0),
                 container.anvilMatrix.getStackInRowAndColumn(1, 0)
             };
             if (recipe != null) {
-                if (EventHooks.onRecipeScriptPre(player, recipe.getScriptHandler(), recipe, items)) {
-                    return;
-                }
                 container.updateRepairResult();
                 stack = EventHooks.onRecipeScriptPost(player, recipe.getScriptHandler(), recipe, items, stack);
             }
@@ -319,6 +350,8 @@ public class ContainerAnvilRepair extends Container {
             }
             container.repairCost = 0;
             container.updateRepairResult();
+            preChecked = false;
+            canPickup = true;
             super.onPickupFromSlot(player, stack);
         }
     }

--- a/src/main/java/noppes/npcs/containers/ContainerCarpentryBench.java
+++ b/src/main/java/noppes/npcs/containers/ContainerCarpentryBench.java
@@ -112,6 +112,10 @@ public class ContainerCarpentryBench extends Container {
             var2 = var4.copy();
 
             if (par1 == 0) {
+                SlotCarpentryResult resultSlot = (SlotCarpentryResult) var3;
+                if (!resultSlot.preEvent(par1EntityPlayer)) {
+                    return null;
+                }
                 if (!this.mergeItemStack(var4, 17, 53, true)) {
                     return null;
                 }
@@ -159,6 +163,8 @@ public class ContainerCarpentryBench extends Container {
     private class SlotCarpentryResult extends SlotCrafting {
         private final ContainerCarpentryBench container;
         private final InventoryCrafting matrix;
+        private boolean preChecked = false;
+        private boolean canPickup = true;
 
         public SlotCarpentryResult(ContainerCarpentryBench container, EntityPlayer player, InventoryCrafting matrix, IInventory result, int index, int x, int y) {
             super(player, matrix, result, index, x, y);
@@ -166,20 +172,50 @@ public class ContainerCarpentryBench extends Container {
             this.matrix = matrix;
         }
 
+        public boolean preEvent(EntityPlayer player) {
+            preChecked = true;
+            RecipeCarpentry recipe = container.currentRecipe;
+            if (recipe != null) {
+                ItemStack[] items = new ItemStack[matrix.getSizeInventory()];
+                for (int i = 0; i < items.length; i++) {
+                    items[i] = matrix.getStackInSlot(i);
+                }
+                canPickup = !EventHooks.onRecipeScriptPre(player, recipe.getScriptHandler(), recipe, items);
+                if (!canPickup) {
+                    container.onCraftMatrixChanged(matrix);
+                }
+            } else {
+                canPickup = true;
+            }
+            return canPickup;
+        }
+
+        @Override
+        public boolean canTakeStack(EntityPlayer player) {
+            if (!preChecked) {
+                preEvent(player);
+            }
+            return canPickup && super.canTakeStack(player);
+        }
+
         @Override
         public void onPickupFromSlot(EntityPlayer player, ItemStack stack) {
-            RecipeCarpentry recipe = container.currentRecipe;
-            ItemStack[] items = new ItemStack[matrix.getSizeInventory()];
-            for (int i = 0; i < items.length; i++) {
-                items[i] = matrix.getStackInSlot(i);
-            }
-            if (recipe != null) {
-                if (EventHooks.onRecipeScriptPre(player, recipe.getScriptHandler(), recipe, items)) {
-                    container.onCraftMatrixChanged(matrix);
+            if (!preChecked) {
+                if (!preEvent(player))
                     return;
+            }
+            if (!canPickup)
+                return;
+            RecipeCarpentry recipe = container.currentRecipe;
+            if (recipe != null) {
+                ItemStack[] items = new ItemStack[matrix.getSizeInventory()];
+                for (int i = 0; i < items.length; i++) {
+                    items[i] = matrix.getStackInSlot(i);
                 }
                 stack = EventHooks.onRecipeScriptPost(player, recipe.getScriptHandler(), recipe, items, stack);
             }
+            preChecked = false;
+            canPickup = true;
             super.onPickupFromSlot(player, stack);
         }
     }


### PR DESCRIPTION
## Summary
- prevent picking up crafting or repair result if the recipe pre event is cancelled
- centralize pre-event logic in custom output slot classes

## Testing
- `./gradlew build` *(fails: Compilation failed; see the compiler error output for details)*

------
https://chatgpt.com/codex/tasks/task_e_686ecaa73eac8323bfc2a678357713b2