### PR TITLE
Fix bard sound duplication

### DIFF
--- a/src/main/java/noppes/npcs/client/controllers/MusicController.java
+++ b/src/main/java/noppes/npcs/client/controllers/MusicController.java
@@ -56,15 +56,21 @@ public class MusicController {
 
     public void stopMusic() {
         SoundHandler soundHandler = Minecraft.getMinecraft().getSoundHandler();
-        if (soundHandler != null) {
+        if (this.playingSound != null) {
+            if (soundHandler != null) {
+                try {
+                    soundHandler.stopSound(this.playingSound);
+                } catch (Exception ignored) {
+                }
+            }
+            this.playingSound.stopSound();
+            this.sounds.remove(this.playingSound.sound);
+            this.playingSound = null;
+        } else if (soundHandler != null) {
             try {
                 soundHandler.stopSounds();
             } catch (Exception ignored) {
             }
-        }
-        if (this.playingSound != null) {
-            this.playingSound.stopSound();
-            this.playingSound = null;
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid leftover sound instances when stopping bard music

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d5c30daf4832389ef61ab2ddcc728