### PR TITLE
Fix target lost event trigger

### DIFF
--- a/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
+++ b/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
@@ -653,8 +653,8 @@ public abstract class EntityNPCInterface extends EntityCreature implements IEnti
                     entity = null;
                 else
                     entity = event.getTarget().getMCEntity();
-            } else {
-                if (EventHooks.onNPCTargetLost(this, getAttackTarget(), entity))
+            } else if (entity == null && getAttackTarget() != null) {
+                if (EventHooks.onNPCTargetLost(this, getAttackTarget(), null))
                     return;
             }
             if (entity != null && entity != this && ais.onAttack != 3 && !isAttacking()) {


### PR DESCRIPTION
## Summary
- don't trigger `targetLost` event when NPC already has a target

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6868a55ed3d88323b64424d3336e18cd