### PR TITLE
Fix bracket highlight crash

### DIFF
--- a/src/main/java/noppes/npcs/client/gui/util/GuiScriptTextArea.java
+++ b/src/main/java/noppes/npcs/client/gui/util/GuiScriptTextArea.java
@@ -91,7 +91,8 @@ public class GuiScriptTextArea extends GuiNpcTextField {
             scrolledLine = Math.min(Math.max((int) (1f * diff * (yMouse - y) / height), 0), diff);
         }
         int startBracket = 0, endBracket = 0;
-        if (endSelection - startSelection == 1 || startSelection == endSelection && startSelection < text.length()) {
+        if (startSelection >= 0 && startSelection < text.length() &&
+                (endSelection - startSelection == 1 || startSelection == endSelection)) {
             char c = text.charAt(startSelection);
             int found = 0;
             if (c == '{') {


### PR DESCRIPTION
## Summary
- guard bracket detection from invalid cursor positions

## Testing
- `./gradlew tasks --all`
- `./gradlew build -x test` *(fails: package noppes.npcs.api does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6880b1a96e2483238001f445a3813579