### PR TITLE
Fix flying NPCs falling when gravity set to 0

### DIFF
--- a/src/main/java/noppes/npcs/entity/EntityNPCFlying.java
+++ b/src/main/java/noppes/npcs/entity/EntityNPCFlying.java
@@ -35,6 +35,14 @@ public abstract class EntityNPCFlying extends EntityNPCInterface {
         return false;
     }
 
+    @Override
+    public void onLivingUpdate() {
+        super.onLivingUpdate();
+        if (this.canFly() && this.getNavigator().noPath()) {
+            this.motionY = -Math.abs(this.ais.flyGravity);
+        }
+    }
+
     public void moveEntityWithHeading(float p_70612_1_, float p_70612_2_) {
         if (!this.canFly() || this.hurtTime != 0 || !this.canBreathe()) {
             super.moveEntityWithHeading(p_70612_1_, p_70612_2_);


### PR DESCRIPTION
## Summary
- override `onLivingUpdate` for `EntityNPCFlying` to enforce custom gravity after the vanilla update step

## Testing
- `./gradlew tasks --all`
- `./gradlew build --console=plain` *(fails: invalid stored block lengths)*

------
https://chatgpt.com/codex/tasks/task_e_6880b20fad108323b62d320817517be1