### PR TITLE
Add caching for 3D skin layer models

### DIFF
--- a/src/main/java/noppes/npcs/client/ClientCacheHandler.java
+++ b/src/main/java/noppes/npcs/client/ClientCacheHandler.java
@@ -10,6 +10,7 @@ import noppes.npcs.client.gui.hud.HudComponent;
 import noppes.npcs.client.gui.select.GuiSoundSelection;
 import noppes.npcs.client.gui.select.GuiTextureSelection;
 import noppes.npcs.client.renderer.ImageData;
+import noppes.npcs.client.model.skin3d.SkinLayerCache;
 import noppes.npcs.config.ConfigClient;
 import noppes.npcs.controllers.data.AnimationData;
 import noppes.npcs.controllers.data.Party;
@@ -82,6 +83,9 @@ public class ClientCacheHandler {
         ClientCacheHandler.imageDataCache.clear();
         ClientCacheHandler.customOverlays.clear();
         ClientCacheHandler.skinOverlays.clear();
+
+        // Clear 3D layer cache
+        SkinLayerCache.clearCache();
 
         // Clear Texture Caches
         GuiSoundSelection.cachedDomains.clear();

--- a/src/main/java/noppes/npcs/client/model/ModelMPM.java
+++ b/src/main/java/noppes/npcs/client/model/ModelMPM.java
@@ -16,6 +16,9 @@ import noppes.npcs.client.model.animation.AniHug;
 import noppes.npcs.client.model.part.*;
 import noppes.npcs.client.model.util.ModelPartInterface;
 import noppes.npcs.client.model.util.ModelScaleRenderer;
+import noppes.npcs.client.model.skin3d.PixelModelPart;
+import noppes.npcs.client.model.skin3d.SkinLayerUtil;
+import noppes.npcs.client.model.skin3d.SkinLayerCache;
 import noppes.npcs.client.renderer.ImageData;
 import noppes.npcs.constants.EnumAnimation;
 import noppes.npcs.constants.EnumAnimationPart;
@@ -63,6 +66,12 @@ public class ModelMPM extends ModelNPCMale {
     public ModelTail tail;
     public ModelBase entityModel;
     public EntityLivingBase entity;
+    private PixelModelPart headLayer3d;
+    private PixelModelPart bodyLayer3d;
+    private PixelModelPart rightArmLayer3d;
+    private PixelModelPart leftArmLayer3d;
+    private PixelModelPart rightLegLayer3d;
+    private PixelModelPart leftLegLayer3d;
 
     public boolean currentlyPlayerTexture;
 
@@ -750,8 +759,19 @@ public class ModelMPM extends ModelNPCMale {
                 ((ModelScaleRenderer) this.bipedHeadwear).setConfig(head, x, y, z);
                 ((ModelScaleRenderer) this.bipedHeadwear).render(f);
             } else if (entity.modelData.headwear == 2) {
-                this.headwear.setConfig(head, x, y, z);
-                this.headwear.render(f);
+                if (headLayer3d == null) {
+                    ImageData data = ClientCacheHandler.getNPCTexture(entity.display.url, entity.display.skinType == 3, entity.textureLocation);
+                    SkinLayerCache.LayerSet layers = SkinLayerCache.getLayers(data, isAlexArmor);
+                    if (layers != null) {
+                        headLayer3d = layers.head;
+                    }
+                }
+                if (headLayer3d != null) {
+                    GL11.glPushMatrix();
+                    this.bipedHead.postRender(0.0625F);
+                    headLayer3d.render();
+                    GL11.glPopMatrix();
+                }
             }
         }
         ((ModelScaleRenderer) this.bipedHead).setConfig(head, x, y, z);
@@ -780,6 +800,21 @@ public class ModelMPM extends ModelNPCMale {
         // Hide Bodywear
         this.bipedBodywear.isHidden = entity.modelData.bodywear != 1;
         this.bodywear.isHidden = entity.modelData.bodywear != 2;
+        if(entity.modelData.bodywear == 2){
+            if(bodyLayer3d == null){
+                ImageData data = ClientCacheHandler.getNPCTexture(entity.display.url, entity.display.skinType == 3, entity.textureLocation);
+                SkinLayerCache.LayerSet layers = SkinLayerCache.getLayers(data, isAlexArmor);
+                if(layers != null){
+                    bodyLayer3d = layers.body;
+                }
+            }
+            if(bodyLayer3d != null){
+                GL11.glPushMatrix();
+                this.bipedBody.postRender(0.0625F);
+                bodyLayer3d.render();
+                GL11.glPopMatrix();
+            }
+        }
 
         ((ModelScaleRenderer) this.bipedBody).setConfig(body, x, y, z);
         ((ModelScaleRenderer) this.bipedBody).render(f);
@@ -846,6 +881,38 @@ public class ModelMPM extends ModelNPCMale {
             this.solidLeftArmWear.isHidden = true;
         }
 
+        if(entity.modelData.rightArmWear() == 2){
+            if(rightArmLayer3d == null){
+                ImageData data = ClientCacheHandler.getNPCTexture(entity.display.url, entity.display.skinType == 3, entity.textureLocation);
+                SkinLayerCache.LayerSet layers = SkinLayerCache.getLayers(data, isAlexArmor);
+                if(layers != null){
+                    rightArmLayer3d = layers.rightArm;
+                }
+            }
+            if(rightArmLayer3d != null){
+                GL11.glPushMatrix();
+                this.bipedRightArm.postRender(0.0625F);
+                rightArmLayer3d.render();
+                GL11.glPopMatrix();
+            }
+        }
+
+        if(entity.modelData.leftArmWear() == 2){
+            if(leftArmLayer3d == null){
+                ImageData data = ClientCacheHandler.getNPCTexture(entity.display.url, entity.display.skinType == 3, entity.textureLocation);
+                SkinLayerCache.LayerSet layers = SkinLayerCache.getLayers(data, isAlexArmor);
+                if(layers != null){
+                    leftArmLayer3d = layers.leftArm;
+                }
+            }
+            if(leftArmLayer3d != null){
+                GL11.glPushMatrix();
+                this.bipedLeftArm.postRender(0.0625F);
+                leftArmLayer3d.render();
+                GL11.glPopMatrix();
+            }
+        }
+
         loadPlayerTexture(entity);
         if (!bo) {
             ((ModelScaleRenderer) this.bipedLeftArm).setConfig(arms, -x, y, z);
@@ -907,11 +974,44 @@ public class ModelMPM extends ModelNPCMale {
 
             this.solidRightLegWear.isHidden = entity.modelData.solidLegwear == 0 || entity.modelData.solidLegwear == 2;
             this.solidLeftLegWear.isHidden = true;
+
         } else {
             ((ModelScaleRenderer) this.bipedRightLegWear).isHidden = true;
             ((ModelScaleRenderer) this.bipedLeftLegWear).isHidden = true;
             this.solidRightLegWear.isHidden = true;
             this.solidLeftLegWear.isHidden = true;
+        }
+
+        if(entity.modelData.rightLegWear() == 2){
+            if(rightLegLayer3d == null){
+                ImageData data = ClientCacheHandler.getNPCTexture(entity.display.url, entity.display.skinType == 3, entity.textureLocation);
+                SkinLayerCache.LayerSet layers = SkinLayerCache.getLayers(data, isAlexArmor);
+                if(layers != null){
+                    rightLegLayer3d = layers.rightLeg;
+                }
+            }
+            if(rightLegLayer3d != null){
+                GL11.glPushMatrix();
+                this.bipedRightLeg.postRender(0.0625F);
+                rightLegLayer3d.render();
+                GL11.glPopMatrix();
+            }
+        }
+
+        if(entity.modelData.leftLegWear() == 2){
+            if(leftLegLayer3d == null){
+                ImageData data = ClientCacheHandler.getNPCTexture(entity.display.url, entity.display.skinType == 3, entity.textureLocation);
+                SkinLayerCache.LayerSet layers = SkinLayerCache.getLayers(data, isAlexArmor);
+                if(layers != null){
+                    leftLegLayer3d = layers.leftLeg;
+                }
+            }
+            if(leftLegLayer3d != null){
+                GL11.glPushMatrix();
+                this.bipedLeftLeg.postRender(0.0625F);
+                leftLegLayer3d.render();
+                GL11.glPopMatrix();
+            }
         }
 
         this.legs.setConfig(legs, x, y, z);

--- a/src/main/java/noppes/npcs/client/model/skin3d/FaceDirection.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/FaceDirection.java
@@ -1,0 +1,25 @@
+package noppes.npcs.client.model.skin3d;
+
+import net.minecraft.util.Vec3i;
+import net.minecraft.util.Vec3;
+
+public enum FaceDirection {
+    DOWN(new Vec3i(0, -1, 0)),
+    UP(new Vec3i(0, 1, 0)),
+    NORTH(new Vec3i(0, 0, -1)),
+    SOUTH(new Vec3i(0, 0, 1)),
+    WEST(new Vec3i(-1, 0, 0)),
+    EAST(new Vec3i(1, 0, 0));
+
+    private final Vec3i normal;
+
+    FaceDirection(Vec3i normal) {
+        this.normal = normal;
+    }
+
+    public int getStepX() { return normal.getX(); }
+    public int getStepY() { return normal.getY(); }
+    public int getStepZ() { return normal.getZ(); }
+
+    public Vec3 step() { return new Vec3(getStepX(), getStepY(), getStepZ()); }
+}

--- a/src/main/java/noppes/npcs/client/model/skin3d/FaceDirection.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/FaceDirection.java
@@ -1,25 +1,28 @@
 package noppes.npcs.client.model.skin3d;
 
-import net.minecraft.util.Vec3i;
 import net.minecraft.util.Vec3;
 
 public enum FaceDirection {
-    DOWN(new Vec3i(0, -1, 0)),
-    UP(new Vec3i(0, 1, 0)),
-    NORTH(new Vec3i(0, 0, -1)),
-    SOUTH(new Vec3i(0, 0, 1)),
-    WEST(new Vec3i(-1, 0, 0)),
-    EAST(new Vec3i(1, 0, 0));
+    DOWN(0, -1, 0),
+    UP(0, 1, 0),
+    NORTH(0, 0, -1),
+    SOUTH(0, 0, 1),
+    WEST(-1, 0, 0),
+    EAST(1, 0, 0);
 
-    private final Vec3i normal;
+    private final int stepX;
+    private final int stepY;
+    private final int stepZ;
 
-    FaceDirection(Vec3i normal) {
-        this.normal = normal;
+    FaceDirection(int x, int y, int z) {
+        this.stepX = x;
+        this.stepY = y;
+        this.stepZ = z;
     }
 
-    public int getStepX() { return normal.getX(); }
-    public int getStepY() { return normal.getY(); }
-    public int getStepZ() { return normal.getZ(); }
+    public int getStepX() { return stepX; }
+    public int getStepY() { return stepY; }
+    public int getStepZ() { return stepZ; }
 
-    public Vec3 step() { return Vec3.createVectorHelper(getStepX(), getStepY(), getStepZ()); }
+    public Vec3 step() { return Vec3.createVectorHelper(stepX, stepY, stepZ); }
 }

--- a/src/main/java/noppes/npcs/client/model/skin3d/FaceDirection.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/FaceDirection.java
@@ -21,5 +21,5 @@ public enum FaceDirection {
     public int getStepY() { return normal.getY(); }
     public int getStepZ() { return normal.getZ(); }
 
-    public Vec3 step() { return new Vec3(getStepX(), getStepY(), getStepZ()); }
+    public Vec3 step() { return Vec3.createVectorHelper(getStepX(), getStepY(), getStepZ()); }
 }

--- a/src/main/java/noppes/npcs/client/model/skin3d/PixelCube.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/PixelCube.java
@@ -43,10 +43,10 @@ public class PixelCube {
     }
 
     public void render(Tessellator tess) {
-        int id=0;
+        int id = 0;
         for(FaceDirection dir : FaceDirection.values()) {
             if(!hidden.contains(dir)) {
-                quads[id].draw(tess.getWorldRenderer(), 1/16f);
+                quads[id].draw(tess, 1/16f);
             }
             id++;
         }

--- a/src/main/java/noppes/npcs/client/model/skin3d/PixelCube.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/PixelCube.java
@@ -33,12 +33,13 @@ public class PixelCube {
         PositionTextureVertex v7 = new PositionTextureVertex(px2, maxY, maxZ, (u+size)/texW, (v+size)/texH);
         PositionTextureVertex v8 = new PositionTextureVertex(px, maxY, maxZ, (u)/texW, (v+size)/texH);
 
-        quads[0] = new TexturedQuad(new PositionTextureVertex[]{v6,v5,v1,v2}); //down
-        quads[1] = new TexturedQuad(new PositionTextureVertex[]{v3,v4,v8,v7}); //up
-        quads[2] = new TexturedQuad(new PositionTextureVertex[]{v5,v6,v7,v8}); //south
-        quads[3] = new TexturedQuad(new PositionTextureVertex[]{v2,v1,v4,v3}); //north
-        quads[4] = new TexturedQuad(new PositionTextureVertex[]{v6,v2,v3,v7}); //east
-        quads[5] = new TexturedQuad(new PositionTextureVertex[]{v1,v5,v8,v4}); //west
+        // order must match FaceDirection.values()
+        quads[0] = new TexturedQuad(new PositionTextureVertex[]{v6, v5, v1, v2}); // DOWN
+        quads[1] = new TexturedQuad(new PositionTextureVertex[]{v3, v4, v8, v7}); // UP
+        quads[2] = new TexturedQuad(new PositionTextureVertex[]{v2, v1, v4, v3}); // NORTH
+        quads[3] = new TexturedQuad(new PositionTextureVertex[]{v5, v6, v7, v8}); // SOUTH
+        quads[4] = new TexturedQuad(new PositionTextureVertex[]{v1, v5, v8, v4}); // WEST
+        quads[5] = new TexturedQuad(new PositionTextureVertex[]{v6, v2, v3, v7}); // EAST
     }
 
     public void render(Tessellator tess) {

--- a/src/main/java/noppes/npcs/client/model/skin3d/PixelCube.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/PixelCube.java
@@ -1,0 +1,53 @@
+package noppes.npcs.client.model.skin3d;
+
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.model.TexturedQuad;
+import net.minecraft.client.model.PositionTextureVertex;
+import java.util.EnumSet;
+
+public class PixelCube {
+    private final float minX, minY, minZ;
+    private final float maxX, maxY, maxZ;
+    private final EnumSet<FaceDirection> hidden;
+    private final TexturedQuad[] quads = new TexturedQuad[6];
+
+    public PixelCube(int u, int v, float x, float y, float z, float size, boolean mirror, int texW, int texH, FaceDirection[] hide) {
+        this.minX = x;
+        this.minY = y;
+        this.minZ = z;
+        this.maxX = x + size;
+        this.maxY = y + size;
+        this.maxZ = z + size;
+        this.hidden = EnumSet.noneOf(FaceDirection.class);
+        if(hide != null) {
+            for(FaceDirection d : hide) hidden.add(d);
+        }
+        float px = mirror ? maxX : minX;
+        float px2 = mirror ? minX : maxX;
+        PositionTextureVertex v1 = new PositionTextureVertex(px, minY, minZ, (u)/texW, (v)/texH);
+        PositionTextureVertex v2 = new PositionTextureVertex(px2, minY, minZ, (u+size)/texW, (v)/texH);
+        PositionTextureVertex v3 = new PositionTextureVertex(px2, maxY, minZ, (u+size)/texW, (v+size)/texH);
+        PositionTextureVertex v4 = new PositionTextureVertex(px, maxY, minZ, (u)/texW, (v+size)/texH);
+        PositionTextureVertex v5 = new PositionTextureVertex(px, minY, maxZ, (u)/texW, (v)/texH);
+        PositionTextureVertex v6 = new PositionTextureVertex(px2, minY, maxZ, (u+size)/texW, (v)/texH);
+        PositionTextureVertex v7 = new PositionTextureVertex(px2, maxY, maxZ, (u+size)/texW, (v+size)/texH);
+        PositionTextureVertex v8 = new PositionTextureVertex(px, maxY, maxZ, (u)/texW, (v+size)/texH);
+
+        quads[0] = new TexturedQuad(new PositionTextureVertex[]{v6,v5,v1,v2}); //down
+        quads[1] = new TexturedQuad(new PositionTextureVertex[]{v3,v4,v8,v7}); //up
+        quads[2] = new TexturedQuad(new PositionTextureVertex[]{v5,v6,v7,v8}); //south
+        quads[3] = new TexturedQuad(new PositionTextureVertex[]{v2,v1,v4,v3}); //north
+        quads[4] = new TexturedQuad(new PositionTextureVertex[]{v6,v2,v3,v7}); //east
+        quads[5] = new TexturedQuad(new PositionTextureVertex[]{v1,v5,v8,v4}); //west
+    }
+
+    public void render(Tessellator tess) {
+        int id=0;
+        for(FaceDirection dir : FaceDirection.values()) {
+            if(!hidden.contains(dir)) {
+                quads[id].draw(tess.getWorldRenderer(), 1/16f);
+            }
+            id++;
+        }
+    }
+}

--- a/src/main/java/noppes/npcs/client/model/skin3d/PixelCubeListBuilder.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/PixelCubeListBuilder.java
@@ -1,0 +1,43 @@
+package noppes.npcs.client.model.skin3d;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PixelCubeListBuilder {
+    private int texU;
+    private int texV;
+    private int texWidth = 64;
+    private int texHeight = 64;
+    private boolean mirror;
+    private final List<PixelCube> cubes = new ArrayList<PixelCube>();
+
+    public static PixelCubeListBuilder create() {
+        return new PixelCubeListBuilder();
+    }
+
+    public PixelCubeListBuilder texOffs(int u, int v) {
+        this.texU = u;
+        this.texV = v;
+        return this;
+    }
+
+    public PixelCubeListBuilder mirror(boolean mirror) {
+        this.mirror = mirror;
+        return this;
+    }
+
+    public PixelCubeListBuilder texSize(int width, int height){
+        this.texWidth = width;
+        this.texHeight = height;
+        return this;
+    }
+
+    public PixelCubeListBuilder addBox(float x, float y, float z, float size, FaceDirection[] hide) {
+        cubes.add(new PixelCube(texU, texV, x, y, z, size, mirror, texWidth, texHeight, hide));
+        return this;
+    }
+
+    public List<PixelCube> getCubes() {
+        return cubes;
+    }
+}

--- a/src/main/java/noppes/npcs/client/model/skin3d/PixelModelPart.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/PixelModelPart.java
@@ -21,11 +21,9 @@ public class PixelModelPart {
         GL11.glPushMatrix();
         GL11.glTranslatef(x/16f, y/16f, z/16f);
         Tessellator tess = Tessellator.instance;
-        tess.startDrawingQuads();
         for(PixelCube cube : cubes) {
             cube.render(tess);
         }
-        tess.draw();
         GL11.glPopMatrix();
     }
 }

--- a/src/main/java/noppes/npcs/client/model/skin3d/PixelModelPart.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/PixelModelPart.java
@@ -3,7 +3,7 @@ package noppes.npcs.client.model.skin3d;
 import java.util.List;
 
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.GlStateManager;
+import org.lwjgl.opengl.GL11;
 
 public class PixelModelPart {
     private final List<PixelCube> cubes;
@@ -18,14 +18,14 @@ public class PixelModelPart {
 
     public void render() {
         if(!visible) return;
-        GlStateManager.pushMatrix();
-        GlStateManager.translate(x/16f, y/16f, z/16f);
+        GL11.glPushMatrix();
+        GL11.glTranslatef(x/16f, y/16f, z/16f);
         Tessellator tess = Tessellator.instance;
         tess.startDrawingQuads();
         for(PixelCube cube : cubes) {
             cube.render(tess);
         }
         tess.draw();
-        GlStateManager.popMatrix();
+        GL11.glPopMatrix();
     }
 }

--- a/src/main/java/noppes/npcs/client/model/skin3d/PixelModelPart.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/PixelModelPart.java
@@ -1,0 +1,31 @@
+package noppes.npcs.client.model.skin3d;
+
+import java.util.List;
+
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.GlStateManager;
+
+public class PixelModelPart {
+    private final List<PixelCube> cubes;
+    public float x;
+    public float y;
+    public float z;
+    public boolean visible = true;
+
+    public PixelModelPart(List<PixelCube> cubes) {
+        this.cubes = cubes;
+    }
+
+    public void render() {
+        if(!visible) return;
+        GlStateManager.pushMatrix();
+        GlStateManager.translate(x/16f, y/16f, z/16f);
+        Tessellator tess = Tessellator.instance;
+        tess.startDrawingQuads();
+        for(PixelCube cube : cubes) {
+            cube.render(tess);
+        }
+        tess.draw();
+        GlStateManager.popMatrix();
+    }
+}

--- a/src/main/java/noppes/npcs/client/model/skin3d/PixelModelPart.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/PixelModelPart.java
@@ -3,13 +3,9 @@ package noppes.npcs.client.model.skin3d;
 import java.util.List;
 
 import net.minecraft.client.renderer.Tessellator;
-import org.lwjgl.opengl.GL11;
 
 public class PixelModelPart {
     private final List<PixelCube> cubes;
-    public float x;
-    public float y;
-    public float z;
     public boolean visible = true;
 
     public PixelModelPart(List<PixelCube> cubes) {
@@ -18,12 +14,9 @@ public class PixelModelPart {
 
     public void render() {
         if(!visible) return;
-        GL11.glPushMatrix();
-        GL11.glTranslatef(x/16f, y/16f, z/16f);
         Tessellator tess = Tessellator.instance;
         for(PixelCube cube : cubes) {
             cube.render(tess);
         }
-        GL11.glPopMatrix();
     }
 }

--- a/src/main/java/noppes/npcs/client/model/skin3d/SkinLayerCache.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/SkinLayerCache.java
@@ -1,0 +1,59 @@
+package noppes.npcs.client.model.skin3d;
+
+import noppes.npcs.client.renderer.ImageData;
+import noppes.npcs.config.ConfigClient;
+import noppes.npcs.util.CacheHashMap;
+import net.minecraft.util.ResourceLocation;
+
+import java.awt.image.BufferedImage;
+
+// classes for 3D layer building
+import noppes.npcs.client.model.skin3d.PixelModelPart;
+import noppes.npcs.client.model.skin3d.SkinLayerUtil;
+
+public class SkinLayerCache {
+    private static final CacheHashMap<String, CacheHashMap.CachedObject<LayerSet>> CACHE =
+            new CacheHashMap<>((long) ConfigClient.CacheLife * 60 * 1000);
+
+    public static class LayerSet {
+        public PixelModelPart head;
+        public PixelModelPart body;
+        public PixelModelPart rightArm;
+        public PixelModelPart leftArm;
+        public PixelModelPart rightLeg;
+        public PixelModelPart leftLeg;
+    }
+
+    private static String key(ResourceLocation loc, boolean slim){
+        return loc.getResourcePath() + (slim ? "#slim" : "#normal");
+    }
+
+    public static LayerSet getLayers(ImageData data, boolean slim){
+        if(data == null || data.getLocation() == null)
+            return null;
+        String k = key(data.getLocation(), slim);
+        synchronized (CACHE){
+            CacheHashMap.CachedObject<LayerSet> ref = CACHE.get(k);
+            if(ref != null)
+                return ref.getObject();
+            LayerSet set = new LayerSet();
+            BufferedImage img = data.getBufferedImage();
+            if(img != null){
+                set.head = SkinLayerUtil.buildHeadLayer(img);
+                set.body = SkinLayerUtil.buildBodyLayer(img);
+                set.rightArm = SkinLayerUtil.buildArmLayer(img, false, slim);
+                set.leftArm = SkinLayerUtil.buildArmLayer(img, true, slim);
+                set.rightLeg = SkinLayerUtil.buildLegLayer(img, false);
+                set.leftLeg = SkinLayerUtil.buildLegLayer(img, true);
+            }
+            CACHE.put(k, new CacheHashMap.CachedObject<>(set));
+            return set;
+        }
+    }
+
+    public static void clearCache(){
+        synchronized (CACHE){
+            CACHE.clear();
+        }
+    }
+}

--- a/src/main/java/noppes/npcs/client/model/skin3d/SkinLayerUtil.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/SkinLayerUtil.java
@@ -1,0 +1,41 @@
+package noppes.npcs.client.model.skin3d;
+
+import java.awt.image.BufferedImage;
+
+public class SkinLayerUtil {
+    private static boolean hasSecondLayer(BufferedImage skin){
+        return skin.getHeight() >= skin.getWidth();
+    }
+
+    private static int scale(float value,float scale){
+        return Math.round(value*scale);
+    }
+
+    public static PixelModelPart buildHeadLayer(BufferedImage skin){
+        if(skin==null || !hasSecondLayer(skin)) return null;
+        float s = skin.getWidth()/64f;
+        return TransparentPixelWrapper.wrapBox(skin,scale(8,s),scale(8,s),scale(8,s),scale(32,s),0);
+    }
+
+    public static PixelModelPart buildBodyLayer(BufferedImage skin){
+        if(skin==null || !hasSecondLayer(skin)) return null;
+        float s = skin.getWidth()/64f;
+        return TransparentPixelWrapper.wrapBox(skin,scale(8,s),scale(12,s),scale(4,s),scale(16,s),scale(32,s));
+    }
+
+    public static PixelModelPart buildArmLayer(BufferedImage skin, boolean left, boolean slim){
+        if(skin==null || !hasSecondLayer(skin)) return null;
+        float s = skin.getWidth()/64f;
+        int w = slim ? 3 : 4;
+        int u = left ? 40 : 48;
+        int v = left ? 32 : 48;
+        return TransparentPixelWrapper.wrapBox(skin,scale(w,s),scale(12,s),scale(4,s),scale(u,s),scale(v,s));
+    }
+
+    public static PixelModelPart buildLegLayer(BufferedImage skin, boolean left){
+        if(skin==null || !hasSecondLayer(skin)) return null;
+        float s = skin.getWidth()/64f;
+        int v = left ? 32 : 48;
+        return TransparentPixelWrapper.wrapBox(skin,scale(4,s),scale(12,s),scale(4,s),0,scale(v,s));
+    }
+}

--- a/src/main/java/noppes/npcs/client/model/skin3d/SkinLayerUtil.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/SkinLayerUtil.java
@@ -4,7 +4,10 @@ import java.awt.image.BufferedImage;
 
 public class SkinLayerUtil {
     private static boolean hasSecondLayer(BufferedImage skin){
-        return skin.getHeight() >= skin.getWidth();
+        // Support both square(64x64+) and wide(128x64) formats
+        int w = skin.getWidth();
+        int h = skin.getHeight();
+        return h >= 64 || w >= 128;
     }
 
     private static int scale(float value,float scale){

--- a/src/main/java/noppes/npcs/client/model/skin3d/TransparentPixelWrapper.java
+++ b/src/main/java/noppes/npcs/client/model/skin3d/TransparentPixelWrapper.java
@@ -1,0 +1,77 @@
+package noppes.npcs.client.model.skin3d;
+
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class TransparentPixelWrapper {
+    private static final int[][] OFFSETS = new int[][]{{0,1},{0,-1},{1,0},{-1,0}};
+    private static final FaceDirection[] HIDDEN_N = new FaceDirection[]{FaceDirection.WEST,FaceDirection.EAST,FaceDirection.UP,FaceDirection.DOWN};
+    private static final FaceDirection[] HIDDEN_S = new FaceDirection[]{FaceDirection.EAST,FaceDirection.WEST,FaceDirection.UP,FaceDirection.DOWN};
+    private static final FaceDirection[] HIDDEN_W = new FaceDirection[]{FaceDirection.SOUTH,FaceDirection.NORTH,FaceDirection.UP,FaceDirection.DOWN};
+    private static final FaceDirection[] HIDDEN_E = new FaceDirection[]{FaceDirection.NORTH,FaceDirection.SOUTH,FaceDirection.UP,FaceDirection.DOWN};
+    private static final FaceDirection[] HIDDEN_UD = new FaceDirection[]{FaceDirection.EAST,FaceDirection.WEST,FaceDirection.NORTH,FaceDirection.SOUTH};
+
+    public static PixelModelPart wrapBox(BufferedImage img, int width, int height, int depth, int texU, int texV) {
+        List<PixelCube> cubes = new ArrayList<PixelCube>();
+        float pixel = 1f;
+        float ox = -width/2f;
+        float oy = -height;
+        float oz = -depth/2f;
+        for(int u=0;u<width;u++) {
+            for(int v=0;v<height;v++) {
+                addPixel(img,cubes,pixel,isBorder(u,v,width,height),texU+depth+u,texV+depth+v,ox+u,oy+v,oz,FaceDirection.SOUTH);
+                addPixel(img,cubes,pixel,isBorder(u,v,width,height),texU+2*depth+width+u,texV+depth+v,ox+width-1-u,oy+v,oz+depth-1,FaceDirection.NORTH);
+            }
+        }
+        for(int u=0;u<depth;u++) {
+            for(int v=0;v<height;v++) {
+                addPixel(img,cubes,pixel,isBorder(u,v,depth,height),texU-1+depth-u,texV+depth+v,ox,oy+v,oz+u,FaceDirection.EAST);
+                addPixel(img,cubes,pixel,isBorder(u,v,depth,height),texU+depth+width+u,texV+depth+v,ox+width-1f,oy+v,oz+u,FaceDirection.WEST);
+            }
+        }
+        for(int u=0;u<width;u++) {
+            for(int v=0;v<depth;v++) {
+                addPixel(img,cubes,pixel,isBorder(u,v,width,depth),texU+depth+u,texV+depth-1-v,ox+u,oy,oz+v,FaceDirection.UP);
+                addPixel(img,cubes,pixel,isBorder(u,v,width,depth),texU+depth+width+u,texV+depth-1-v,ox+u,oy+height-1f,oz+v,FaceDirection.DOWN);
+            }
+        }
+        return new PixelModelPart(cubes);
+    }
+
+    private static boolean isBorder(int u,int v,int w,int h){
+        return u==0 || v==0 || u==w-1 || v==h-1;
+    }
+
+    private static void addPixel(BufferedImage img,List<PixelCube> cubes,float pixel,boolean border,int u,int v,float x,float y,float z,FaceDirection dir){
+        if(getAlpha(img,u,v)!=0){
+            Set<FaceDirection> hide = new HashSet<FaceDirection>();
+            if(!border){
+                for(int i=0;i<OFFSETS.length;i++){
+                    int tu=u+OFFSETS[i][1];
+                    int tv=v+OFFSETS[i][0];
+                    if(tu>=0 && tu<img.getWidth() && tv>=0 && tv<img.getHeight() && getAlpha(img,tu,tv)!=0){
+                        if(dir==FaceDirection.NORTH)hide.add(HIDDEN_N[i]);
+                        if(dir==FaceDirection.SOUTH)hide.add(HIDDEN_S[i]);
+                        if(dir==FaceDirection.EAST)hide.add(HIDDEN_E[i]);
+                        if(dir==FaceDirection.WEST)hide.add(HIDDEN_W[i]);
+                        if(dir==FaceDirection.UP||dir==FaceDirection.DOWN)hide.add(HIDDEN_UD[i]);
+                    }
+                }
+                hide.add(dir);
+            }
+            cubes.addAll(PixelCubeListBuilder.create()
+                    .texSize(img.getWidth(), img.getHeight())
+                    .texOffs(u-2,v-1)
+                    .addBox(x,y,z,pixel,hide.toArray(new FaceDirection[hide.size()]))
+                    .getCubes());
+        }
+    }
+
+    private static int getAlpha(BufferedImage img,int x,int y){
+        int argb = img.getRGB(x,y);
+        return argb>>>24;
+    }
+}


### PR DESCRIPTION
## Summary
- replace direct `BufferedImage` usage with new `SkinLayerCache`
- cache pixel-based 3D layers per texture to avoid rebuilding
- clear cached layers when `ClientCacheHandler` skin cache is cleared

## Testing
- `./gradlew tasks --all`


------
https://chatgpt.com/codex/tasks/task_e_6872c1e437b48323aa1ed85e2e196c22