### PR TITLE
Fix buildNoMixin task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,13 @@ tasks.create('updateAPI', Exec) {
 }
 
 // No Mixin Build Task
+def gradleWrapper = System.getProperty('os.name').toLowerCase().contains('windows') ? 'gradlew.bat' : './gradlew'
+
 tasks.create('buildNoMixin', Exec) {
     description 'Builds mod without embed'
     group 'CustomNPC+'
-    commandLine 'build', '-Pnomixin'
+    workingDir project.rootDir
+    commandLine gradleWrapper, 'build', '-Pnomixin'
 }
 
 sourceSets {


### PR DESCRIPTION
## Summary
- update `buildNoMixin` task so it calls the Gradle wrapper

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew buildNoMixin --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_68817e8f099c8323ba4b86c7427683be