### PR TITLE
Fix profile region config delimiter

### DIFF
--- a/src/main/java/kamkeel/npcs/command/profile/CommandProfileRegion.java
+++ b/src/main/java/kamkeel/npcs/command/profile/CommandProfileRegion.java
@@ -78,7 +78,7 @@ public class CommandProfileRegion extends CommandProfileBase {
         for (List<Integer> region : ConfigMain.RestrictedProfileRegions) {
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < region.size(); i++) {
-                if (i > 0) sb.append(" ");
+                if (i > 0) sb.append(", ");
                 sb.append(region.get(i));
             }
             regionStrings.add(sb.toString());


### PR DESCRIPTION
## Summary
- save added profile regions with a comma-space delimiter to match the loader

## Testing
- `./gradlew build` *(fails: missing mod dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881a5696a2083239adfb75654b91f7f