### PR TITLE
Fix null leader name NPE

### DIFF
--- a/src/main/java/noppes/npcs/controllers/data/Party.java
+++ b/src/main/java/noppes/npcs/controllers/data/Party.java
@@ -219,7 +219,7 @@ public class Party implements IParty {
     @Override
     public String getPartyLeaderName() {
         if (FMLCommonHandler.instance().getEffectiveSide() == Side.CLIENT) {
-            return this.partyLeaderName;
+            return this.partyLeaderName == null ? "" : this.partyLeaderName;
         } else {
             EntityPlayer leader = this.getPartyLeader();
             if (leader != null)


### PR DESCRIPTION
## Summary
- guard against null `partyLeaderName` in `Party.getPartyLeaderName`

## Testing
- `./gradlew build -Pnomixin` *(fails: Invalid Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_6887b033866c8323b60fce96ab24c99e