### PR TITLE
Fix ClassCastException when interacting with hanging signs

### DIFF
--- a/src/main/java/noppes/npcs/blocks/BlockSign.java
+++ b/src/main/java/noppes/npcs/blocks/BlockSign.java
@@ -11,7 +11,6 @@ import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
-import noppes.npcs.blocks.tiles.TileBanner;
 import noppes.npcs.blocks.tiles.TileSign;
 import noppes.npcs.blocks.tiles.TileVariant;
 
@@ -37,7 +36,7 @@ public class BlockSign extends BlockRotated {
 
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
-        TileBanner tile = (TileBanner) world.getTileEntity(x, y, z);
+        TileSign tile = (TileSign) world.getTileEntity(x, y, z);
         return tile.canEdit();
     }
 


### PR DESCRIPTION
## Summary
- Prevent game crash when right-clicking hanging signs by casting to `TileSign` instead of `TileBanner`

## Testing
- `./gradlew test` *(fails: cannot find symbol classes like IAction, IConditionalAction; compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6a4a4eb08323b596e8f1da9571fe