### PR TITLE
Avoid profile data reset on relog

### DIFF
--- a/src/main/java/kamkeel/npcs/controllers/ProfileController.java
+++ b/src/main/java/kamkeel/npcs/controllers/ProfileController.java
@@ -138,9 +138,16 @@ public class ProfileController implements IProfileHandler {
             if (!profile.getSlots().containsKey(profile.currentSlotId)) {
                 profile.currentSlotId = 0;
             }
+
             profile.player = player;
             activeProfiles.put(player.getUniqueID(), profile);
-            loadSlotData(player);
+
+            PlayerData pdata = PlayerData.get(player);
+            if (profile.getSlots().containsKey(pdata.profileSlot)) {
+                profile.currentSlotId = pdata.profileSlot;
+            }
+
+            saveSlotData(player);
             verifySlotQuests(profile.player);
         }
     }


### PR DESCRIPTION
## Summary
- Sync active slot with player's profileSlot on login
- Save current slot data instead of loading stale data

## Testing
- `./gradlew test` *(fails: package noppes.npcs.api.handler.data does not exist, 100 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b10cba8fe483238984c420504ede8f