### PR TITLE
Allow console scripted commands

### DIFF
--- a/src/main/java/kamkeel/npcs/command/CommandCommand.java
+++ b/src/main/java/kamkeel/npcs/command/CommandCommand.java
@@ -2,7 +2,6 @@ package kamkeel.npcs.command;
 
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.math.BlockPos;
 import noppes.npcs.EventHooks;
@@ -43,13 +42,11 @@ public class CommandCommand extends CommandKamkeelBase {
         ChunkCoordinates senderCoords = sender.getPlayerCoordinates();
         IPos senderPos = NpcAPI.Instance().getIPos(new BlockPos(senderCoords.posX, senderCoords.posY, senderCoords.posZ));
 
-        if (sender instanceof EntityPlayer) {
-            CustomNPCsEvent.ScriptedCommandEvent event = new CustomNPCsEvent.ScriptedCommandEvent(senderWorld, senderPos, sender.getCommandSenderName(), commandId, commandArgs);
-            EventHooks.onScriptedCommand((EntityPlayer) sender, event);
+        CustomNPCsEvent.ScriptedCommandEvent event = new CustomNPCsEvent.ScriptedCommandEvent(senderWorld, senderPos, sender.getCommandSenderName(), commandId, commandArgs);
+        EventHooks.onScriptedCommand(sender, event);
 
-            if (!event.replyMessage.isEmpty()) {
-                sendMessage(sender, event.replyMessage);
-            }
+        if (!event.replyMessage.isEmpty()) {
+            sendMessage(sender, event.replyMessage);
         }
     }
 }

--- a/src/main/java/noppes/npcs/EventHooks.java
+++ b/src/main/java/noppes/npcs/EventHooks.java
@@ -2,6 +2,7 @@ package noppes.npcs;
 
 import cpw.mods.fml.common.eventhandler.Event;
 import kamkeel.npcs.network.packets.data.AchievementPacket;
+import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
@@ -768,8 +769,12 @@ public class EventHooks {
         return false;
     }
 
-    public static boolean onScriptedCommand(EntityPlayer player, CustomNPCsEvent.ScriptedCommandEvent event) {
-        ScriptController.Instance.getPlayerScripts(player).callScript(EnumScriptType.SCRIPT_COMMAND, event);
+    public static boolean onScriptedCommand(ICommandSender sender, CustomNPCsEvent.ScriptedCommandEvent event) {
+        if (sender instanceof EntityPlayer) {
+            ScriptController.Instance.getPlayerScripts((EntityPlayer) sender).callScript(EnumScriptType.SCRIPT_COMMAND, event);
+        } else {
+            ScriptController.Instance.playerScripts.callScript(EnumScriptType.SCRIPT_COMMAND, event);
+        }
         return NpcAPI.EVENT_BUS.post(event);
     }
 


### PR DESCRIPTION
## Summary
- allow the /kam command dispatcher to send scripted custom commands for any command sender
- run scripted command events for non-player senders against the global player script store so console executions trigger scripts

## Testing
- ./gradlew compileJava *(fails: missing noppes.npcs.api dependencies in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4583cb13883238fdbd050d9e9bdeb