### PR TITLE
Fix follower packet to validate follower role

### DIFF
--- a/src/main/java/kamkeel/npcs/network/packets/player/FollowerPacket.java
+++ b/src/main/java/kamkeel/npcs/network/packets/player/FollowerPacket.java
@@ -12,7 +12,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import noppes.npcs.NoppesUtilPlayer;
-import noppes.npcs.constants.EnumJobType;
+import noppes.npcs.constants.EnumRoleType;
 
 import java.io.IOException;
 
@@ -57,7 +57,7 @@ public class FollowerPacket extends AbstractPacket {
 
         EntityPlayerMP playerMP = (EntityPlayerMP) player;
 
-        if (npc.advanced.job != EnumJobType.Follower)
+        if (npc.advanced.role != EnumRoleType.Follower)
             return;
 
         switch (requestedAction) {


### PR DESCRIPTION
## Summary
- ensure follower packet validates that the NPC has the follower role before processing actions

## Testing
- `./gradlew compileJava` *(fails: missing noppes.npcs.api classes in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eee53145688323bb056da94d2896a5