### PR TITLE
Fix NPC hitbox scaling for large sizes

### DIFF
--- a/src/main/java/noppes/npcs/entity/EntityCustomNpc.java
+++ b/src/main/java/noppes/npcs/entity/EntityCustomNpc.java
@@ -68,24 +68,25 @@ public class EntityCustomNpc extends EntityNPCFlying {
         } else {
             if (entity instanceof EntityNPCInterface)
                 ((EntityNPCInterface) entity).updateHitbox();
-            width = (entity.width / 5f) * display.modelSize;
-            height = (entity.height / 5f) * display.modelSize;
+            float newWidth = (entity.width / 5f) * display.modelSize;
+            float newHeight = (entity.height / 5f) * display.modelSize;
             if (display.hitboxData.isHitboxEnabled()) {
-                width = width * display.hitboxData.getWidthScale();
-                height = height * display.hitboxData.getHeightScale();
+                newWidth = newWidth * display.hitboxData.getWidthScale();
+                newHeight = newHeight * display.hitboxData.getHeightScale();
             }
 
-            if (width < 0.1f)
-                width = 0.1f;
-            if (height < 0.1f)
-                height = 0.1f;
             if (isKilled() && stats.hideKilledBody) {
-                width = 0.00001f;
-            }
-            if (width / 2 > worldObj.MAX_ENTITY_RADIUS) {
-                worldObj.MAX_ENTITY_RADIUS = width / 2;
+                newWidth = 0.00001f;
             }
 
+            newWidth = Math.max(newWidth, 0.00001f);
+            newHeight = Math.max(newHeight, 0.00001f);
+
+            if (newWidth / 2 > worldObj.MAX_ENTITY_RADIUS) {
+                worldObj.MAX_ENTITY_RADIUS = newWidth / 2;
+            }
+
+            setSize(newWidth, newHeight);
             this.setPosition(posX, posY, posZ);
         }
     }

--- a/src/main/java/noppes/npcs/entity/EntityNPCGolem.java
+++ b/src/main/java/noppes/npcs/entity/EntityNPCGolem.java
@@ -25,14 +25,21 @@ public class EntityNPCGolem extends EntityNPCInterface {
 
     public void updateHitbox() {
         currentAnimation = EnumAnimation.values()[dataWatcher.getWatchableObjectInt(14)];
+        float newWidth;
+        float newHeight;
         if (currentAnimation == EnumAnimation.LYING) {
-            width = height = 0.5f;
+            newWidth = 0.5f;
+            newHeight = 0.5f;
         } else if (currentAnimation == EnumAnimation.SITTING) {
-            width = 1.4f;
-            height = 2f;
+            newWidth = 1.4f;
+            newHeight = 2f;
         } else {
-            width = 1.4f;
-            height = 2.5f;
+            newWidth = 1.4f;
+            newHeight = 2.5f;
+        }
+        setSize(newWidth, newHeight);
+        if (width / 2 > World.MAX_ENTITY_RADIUS) {
+            World.MAX_ENTITY_RADIUS = width / 2;
         }
     }
 

--- a/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
+++ b/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
@@ -1199,30 +1199,38 @@ public abstract class EntityNPCInterface extends EntityCreature implements IEnti
 
     public void updateHitbox() {
 
+        float newWidth;
+        float newHeight;
         if (currentAnimation == EnumAnimation.LYING || currentAnimation == EnumAnimation.CRAWLING) {
-            width = 0.8f;
-            height = 0.4f;
+            newWidth = 0.8f;
+            newHeight = 0.4f;
         } else if (isRiding()) {
-            width = 0.6f;
-            height = baseHeight * 0.77f;
+            newWidth = 0.6f;
+            newHeight = baseHeight * 0.77f;
         } else {
-            width = 0.6f;
-            height = baseHeight;
+            newWidth = 0.6f;
+            newHeight = baseHeight;
         }
-        width = (width / 5f) * display.modelSize;
-        height = (height / 5f) * display.modelSize;
+        newWidth = (newWidth / 5f) * display.modelSize;
+        newHeight = (newHeight / 5f) * display.modelSize;
 
         if (display.hitboxData.isHitboxEnabled()) {
-            width = width * display.hitboxData.getWidthScale();
-            height = height * display.hitboxData.getHeightScale();
+            newWidth = newWidth * display.hitboxData.getWidthScale();
+            newHeight = newHeight * display.hitboxData.getHeightScale();
         }
 
         if (isKilled() && stats.hideKilledBody) {
-            width = 0.00001f;
+            newWidth = 0.00001f;
         }
-        if (width / 2 > World.MAX_ENTITY_RADIUS) {
-            World.MAX_ENTITY_RADIUS = width / 2;
+
+        newWidth = Math.max(newWidth, 0.00001f);
+        newHeight = Math.max(newHeight, 0.00001f);
+
+        if (newWidth / 2 > World.MAX_ENTITY_RADIUS) {
+            World.MAX_ENTITY_RADIUS = newWidth / 2;
         }
+
+        setSize(newWidth, newHeight);
         this.setPosition(posX, posY, posZ);
     }
 

--- a/src/main/java/noppes/npcs/entity/EntityNpcDragon.java
+++ b/src/main/java/noppes/npcs/entity/EntityNpcDragon.java
@@ -114,8 +114,10 @@ public class EntityNpcDragon extends EntityNPCInterface {
 //    }
     @Override
     public void updateHitbox() {
-        width = 1.8f;
-        height = 1.4f;
+        setSize(1.8f, 1.4f);
+        if (width / 2 > World.MAX_ENTITY_RADIUS) {
+            World.MAX_ENTITY_RADIUS = width / 2;
+        }
     }
 
 }

--- a/src/main/java/noppes/npcs/entity/EntityNpcSlime.java
+++ b/src/main/java/noppes/npcs/entity/EntityNpcSlime.java
@@ -17,8 +17,10 @@ public class EntityNpcSlime extends EntityNPCInterface {
 
     @Override
     public void updateHitbox() {
-        width = 0.8f;
-        height = 0.8f;
+        setSize(0.8f, 0.8f);
+        if (width / 2 > World.MAX_ENTITY_RADIUS) {
+            World.MAX_ENTITY_RADIUS = width / 2;
+        }
     }
 
     @Override

--- a/src/main/java/noppes/npcs/entity/old/EntityNPCEnderman.java
+++ b/src/main/java/noppes/npcs/entity/old/EntityNPCEnderman.java
@@ -24,17 +24,26 @@ public class EntityNPCEnderman extends EntityNpcEnderchibi {
 
     public void updateHitbox() {
 
+        float newWidth;
+        float newHeight;
         if (currentAnimation == EnumAnimation.LYING) {
-            width = height = 0.2f;
+            newWidth = 0.2f;
+            newHeight = 0.2f;
         } else if (currentAnimation == EnumAnimation.SITTING) {
-            width = 0.6f;
-            height = 2.3f;
+            newWidth = 0.6f;
+            newHeight = 2.3f;
         } else {
-            width = 0.6f;
-            height = 2.9f;
+            newWidth = 0.6f;
+            newHeight = 2.9f;
         }
-        width = (width / 5f) * display.modelSize;
-        height = (height / 5f) * display.modelSize;
+        newWidth = (newWidth / 5f) * display.modelSize;
+        newHeight = (newHeight / 5f) * display.modelSize;
+        newWidth = Math.max(newWidth, 0.00001f);
+        newHeight = Math.max(newHeight, 0.00001f);
+        setSize(newWidth, newHeight);
+        if (width / 2 > World.MAX_ENTITY_RADIUS) {
+            World.MAX_ENTITY_RADIUS = width / 2;
+        }
     }
 
     public void onUpdate() {


### PR DESCRIPTION
## Summary
- ensure NPC hitbox updates resize the underlying bounding box via `setSize`
- clamp computed dimensions to safe values and keep world radius updated for oversized NPCs
- apply the same hitbox handling to entity-specific overrides so large sizes stay stable on slabs

## Testing
- ./gradlew updateAPI

------
https://chatgpt.com/codex/tasks/task_e_68f5f9c17438832393bcbe9ecd5ce5f2