### PR TITLE
Fix ScriptBlockPos.add to use provided position offsets

### DIFF
--- a/src/main/java/noppes/npcs/scripted/ScriptBlockPos.java
+++ b/src/main/java/noppes/npcs/scripted/ScriptBlockPos.java
@@ -89,7 +89,7 @@ public class ScriptBlockPos implements IPos {
     }
 
     public IPos add(IPos pos) {
-        return NpcAPI.Instance().getIPos(this.blockPos.add(this.blockPos));
+        return NpcAPI.Instance().getIPos(this.blockPos.add(pos.getXD(), pos.getYD(), pos.getZD()));
     }
 
     public IPos subtract(double x, double y, double z) {


### PR DESCRIPTION
## Summary
- correct ScriptBlockPos#add(IPos) to offset using the provided position rather than the current position

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900393e91108323ba1caf70fd68a665