### PR TITLE
Fix linked item translate axes

### DIFF
--- a/src/main/java/noppes/npcs/scripted/item/ScriptLinkedItem.java
+++ b/src/main/java/noppes/npcs/scripted/item/ScriptLinkedItem.java
@@ -172,6 +172,16 @@ public class ScriptLinkedItem extends ScriptCustomizableItem implements IItemLin
         return this.itemDisplay.translateX != null ? this.itemDisplay.translateX : this.linkedItem.display.translateX;
     }
 
+    @Override
+    public Float getTranslateY() {
+        return this.itemDisplay.translateY != null ? this.itemDisplay.translateY : this.linkedItem.display.translateY;
+    }
+
+    @Override
+    public Float getTranslateZ() {
+        return this.itemDisplay.translateZ != null ? this.itemDisplay.translateZ : this.linkedItem.display.translateZ;
+    }
+
     public NBTTagCompound getMCNbt() {
         NBTTagCompound compound = super.getMCNbt();
         compound.setTag("ItemData", this.getItemNBT(new NBTTagCompound()));


### PR DESCRIPTION
## Summary
- ensure linked items return their configured translate Y and Z values when rendered

## Testing
- `./gradlew compileJava` *(fails: missing CustomNPCs API classes in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_690039ac40fc8323b14df5ed93f965a9