### PR TITLE
Fix SaveBookPacket server handling crash

### DIFF
--- a/src/main/java/kamkeel/npcs/network/packets/player/SaveBookPacket.java
+++ b/src/main/java/kamkeel/npcs/network/packets/player/SaveBookPacket.java
@@ -1,7 +1,5 @@
 package kamkeel.npcs.network.packets.player;
 
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import kamkeel.npcs.network.LargeAbstractPacket;
@@ -52,7 +50,6 @@ public class SaveBookPacket extends LargeAbstractPacket {
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     protected void handleCompleteData(ByteBuf data, EntityPlayer player) throws IOException {
         int x = data.readInt(), y = data.readInt(), z = data.readInt();
 


### PR DESCRIPTION
## Summary
- allow SaveBookPacket to process on the dedicated server by removing the client-only annotation from its handler

## Testing
- `./gradlew compileJava` *(fails: missing CustomNPCs API dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6905bda75da883238d07c9a928c0ee64