### PR TITLE
Reset sync caches between worlds

### DIFF
--- a/src/main/java/kamkeel/npcs/controllers/SyncController.java
+++ b/src/main/java/kamkeel/npcs/controllers/SyncController.java
@@ -86,6 +86,15 @@ public class SyncController {
         registerCache(EnumSyncType.MAGIC_CYCLE, SyncController::magicCyclesNBT);
     }
 
+    public static void resetServerState() {
+        for (SyncCacheEntry entry : CACHE_ENTRIES.values()) {
+            if (entry != null) {
+                entry.reset();
+            }
+        }
+        PLAYER_SYNC_STATE.clear();
+    }
+
     public static void syncPlayer(EntityPlayerMP player) {
         syncPlayer(player, true);
     }
@@ -937,6 +946,12 @@ public class SyncController {
 
         private synchronized int getRevisionValue() {
             return revision;
+        }
+
+        private synchronized void reset() {
+            dirty = true;
+            payload = null;
+            revision = 0;
         }
 
         private static byte[][] splitIntoChunks(byte[] payload) {

--- a/src/main/java/noppes/npcs/CustomNpcs.java
+++ b/src/main/java/noppes/npcs/CustomNpcs.java
@@ -19,6 +19,7 @@ import kamkeel.npcs.command.CommandKamkeel;
 import kamkeel.npcs.command.profile.CommandProfile;
 import kamkeel.npcs.controllers.AttributeController;
 import kamkeel.npcs.controllers.ProfileController;
+import kamkeel.npcs.controllers.SyncController;
 import kamkeel.npcs.controllers.data.profile.CNPCData;
 import kamkeel.npcs.developer.Developer;
 import kamkeel.npcs.network.PacketHandler;
@@ -303,6 +304,7 @@ public class CustomNpcs {
     //Loading items in the about to start event was corrupting items with a damage value
     @EventHandler
     public void started(FMLServerStartedEvent event) {
+        SyncController.resetServerState();
         RecipeController.Instance.load();
         new BankController();
         DialogController.Instance.load();
@@ -315,6 +317,7 @@ public class CustomNpcs {
 
     @EventHandler
     public void stopped(FMLServerStoppedEvent event) {
+        SyncController.resetServerState();
         ServerCloneController.Instance = null;
         GlobalDataController.Instance.saveData();
         ScriptController.Instance.saveForgeScripts();


### PR DESCRIPTION
## Summary
- reset cached sync payloads and player revisions when the server starts or stops
- add an explicit reset on cache entries so dialogs and quests reload for new worlds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690bc60dc59c8323beaeb4f6a1260ea9