### PR TITLE
Scope sync cache rebuild to server load

### DIFF
--- a/src/main/java/noppes/npcs/CustomNpcs.java
+++ b/src/main/java/noppes/npcs/CustomNpcs.java
@@ -304,7 +304,6 @@ public class CustomNpcs {
     //Loading items in the about to start event was corrupting items with a damage value
     @EventHandler
     public void started(FMLServerStartedEvent event) {
-        SyncController.resetServerState();
         RecipeController.Instance.load();
         new BankController();
         DialogController.Instance.load();
@@ -312,6 +311,7 @@ public class CustomNpcs {
         ScriptController.HasStart = true;
         ServerCloneController.Instance = new ServerCloneController();
         ServerTagMapController.Instance = new ServerTagMapController();
+        SyncController.load();
     }
 
 


### PR DESCRIPTION
## Summary
- scope SyncController cache storage to a server-side instance and add a load entry point that rebuilds caches
- clear server sync state through the instance before rebuilding caches so startup priming happens once data loads
- switch the server started hook to call the new load method while keeping rebuildAllCaches as a deprecated alias

## Testing
- ./gradlew updateAPI

------
https://chatgpt.com/codex/tasks/task_e_690bcb5fa694832393c458702c85931c