### PR TITLE
Improve mount movement sync and flight speed

### DIFF
--- a/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
+++ b/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
@@ -2138,9 +2138,11 @@ public abstract class EntityNPCInterface extends EntityCreature implements IEnti
 
         this.jumpMovementFactor = appliedJumpFactor;
 
-        if (!worldObj.isRemote) {
-            this.setAIMoveSpeed(moveSpeed);
-        }
+        // Update move speed on both sides so the client can accurately predict ground
+        // movement when controlling a mount. Only setting it server-side causes visible
+        // delay/desync for ground mounts while the server reconciles the slower client
+        // prediction.
+        this.setAIMoveSpeed(moveSpeed);
 
         super.moveEntityWithHeading(strafe, forward);
 
@@ -2175,9 +2177,11 @@ public abstract class EntityNPCInterface extends EntityCreature implements IEnti
         if (!flightMode) {
             return moveSpeed * 0.1F;
         }
-        final float AIR_FRICTION = 0.91F;
-        final float BASE = 0.16277136F;
-        return moveSpeed * (BASE / (AIR_FRICTION * AIR_FRICTION * AIR_FRICTION));
+        // Keep airborne strafing consistent with on-ground acceleration. Vanilla
+        // ground movement uses the block slipperiness (default 0.6F) which effectively
+        // multiplies moveSpeed by ~1x. Matching that behavior prevents flying mounts
+        // from feeling sluggish compared to their walking speed.
+        return moveSpeed;
     }
 
     private void syncMountedRiderVelocity() {


### PR DESCRIPTION
## Summary
- update mounted AI move speed on both client and server for smoother ground mount prediction
- adjust airborne strafe factor so flying mounts move at the same horizontal speed as walking

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933836d2d3c8323b444d35fe0614138)