### PR TITLE
Harden auctions and trader flows: validation, UI safety, admin cancel/refund, and config fixes

### DIFF
--- a/src/main/java/noppes/npcs/client/gui/player/SubGuiAuctionBid.java
+++ b/src/main/java/noppes/npcs/client/gui/player/SubGuiAuctionBid.java
@@ -35,6 +35,12 @@ public class SubGuiAuctionBid extends SubGuiInterface {
         int y = guiTop + 10;
         int labelColor = 0x404040;
 
+        if (listing.item == null) {
+            addLabel(new GuiNpcLabel(0, StatCollector.translateToLocal("auction.noItemSelected"), guiLeft + 40, y, 0xAA0000));
+            addButton(new GuiNpcButton(31, guiLeft + 60, guiTop + 110, 80, 20, StatCollector.translateToLocal("gui.cancel")));
+            return;
+        }
+
         // Title
         addLabel(new GuiNpcLabel(0, StatCollector.translateToLocal("auction.placeBid"), guiLeft + 70, y, labelColor));
         y += 18;
@@ -70,8 +76,9 @@ public class SubGuiAuctionBid extends SubGuiInterface {
         // Bid input
         addLabel(new GuiNpcLabel(10, StatCollector.translateToLocal("auction.yourBid"), guiLeft + 15, y + 3, labelColor));
         bidField = new GuiNpcTextField(11, this, guiLeft + 80, y, 100, 16, String.valueOf(minBid));
-        bidField.setNumbersOnly();
-        bidField.setMinMaxDefault(minBid, 999999999, minBid);
+        bidField.setIntegersOnly();
+        int minBidInt = (int) Math.min(Integer.MAX_VALUE, Math.max(1L, minBid));
+        bidField.setMinMaxDefault(minBidInt, Integer.MAX_VALUE, minBidInt);
         addTextField(bidField);
         y += 24;
 
@@ -179,7 +186,7 @@ public class SubGuiAuctionBid extends SubGuiInterface {
     }
 
     private void placeBid() {
-        long bidAmount = bidField.getInteger();
+        long bidAmount = parseBid(bidField);
         long minBid = listing.getMinimumBid();
 
         if (bidAmount < minBid) {
@@ -197,6 +204,14 @@ public class SubGuiAuctionBid extends SubGuiInterface {
         // Send bid to server
         AuctionActionPacket.PlaceBid(listing.id, bidAmount);
         close();
+    }
+
+    private long parseBid(GuiNpcTextField field) {
+        try {
+            return Long.parseLong(field.getText());
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
     }
 
     @Override

--- a/src/main/java/noppes/npcs/client/gui/player/SubGuiAuctionCreate.java
+++ b/src/main/java/noppes/npcs/client/gui/player/SubGuiAuctionCreate.java
@@ -51,14 +51,14 @@ public class SubGuiAuctionCreate extends SubGuiInterface {
         // Starting price
         addLabel(new GuiNpcLabel(10, StatCollector.translateToLocal("auction.startingPrice"), guiLeft + 20, guiTop + 70, 0x404040));
         startingPriceField = new GuiNpcTextField(11, this, guiLeft + 100, guiTop + 68, 80, 14, "100");
-        startingPriceField.setNumbersOnly();
+        startingPriceField.setIntegersOnly();
         startingPriceField.setMinMaxDefault(1, 999999999, 100);
         addTextField(startingPriceField);
 
         // Buyout price (optional)
         addLabel(new GuiNpcLabel(20, StatCollector.translateToLocal("auction.buyoutPrice"), guiLeft + 20, guiTop + 90, 0x404040));
         buyoutPriceField = new GuiNpcTextField(21, this, guiLeft + 100, guiTop + 88, 80, 14, "0");
-        buyoutPriceField.setNumbersOnly();
+        buyoutPriceField.setIntegersOnly();
         buyoutPriceField.setMinMaxDefault(0, 999999999, 0);
         addTextField(buyoutPriceField);
         addLabel(new GuiNpcLabel(22, StatCollector.translateToLocal("auction.noBuyoutHint"), guiLeft + 185, guiTop + 90, 0x888888));
@@ -87,7 +87,7 @@ public class SubGuiAuctionCreate extends SubGuiInterface {
 
     private long getListingFee() {
         EnumAuctionDuration duration = EnumAuctionDuration.values()[selectedDuration];
-        return duration.getFee();
+        return duration.getListingFee();
     }
 
     @Override
@@ -113,8 +113,8 @@ public class SubGuiAuctionCreate extends SubGuiInterface {
             return;
         }
 
-        long startingPrice = startingPriceField.getInteger();
-        long buyoutPrice = buyoutPriceField.getInteger();
+        long startingPrice = parsePrice(startingPriceField, 1);
+        long buyoutPrice = parsePrice(buyoutPriceField, 0);
 
         if (startingPrice < 1) {
             startingPrice = 1;
@@ -133,6 +133,14 @@ public class SubGuiAuctionCreate extends SubGuiInterface {
         // Clear slot and close
         container.clearListingSlot();
         close();
+    }
+
+    private long parsePrice(GuiNpcTextField field, long defaultValue) {
+        try {
+            return Long.parseLong(field.getText());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
     }
 
     @Override

--- a/src/main/java/noppes/npcs/client/gui/player/SubGuiAuctionDetails.java
+++ b/src/main/java/noppes/npcs/client/gui/player/SubGuiAuctionDetails.java
@@ -34,6 +34,12 @@ public class SubGuiAuctionDetails extends SubGuiInterface {
         int labelColor = 0x404040;
         int valueColor = 0x000000;
 
+        if (listing.item == null) {
+            addLabel(new GuiNpcLabel(0, StatCollector.translateToLocal("auction.noItemSelected"), guiLeft + 60, y, 0xAA0000));
+            addButton(new GuiNpcButton(50, guiLeft + 80, guiTop + 175, 80, 20, StatCollector.translateToLocal("gui.close")));
+            return;
+        }
+
         // Title
         addLabel(new GuiNpcLabel(0, StatCollector.translateToLocal("auction.auctionDetails"), guiLeft + 80, y, labelColor));
         y += 16;

--- a/src/main/java/noppes/npcs/config/ConfigMarket.java
+++ b/src/main/java/noppes/npcs/config/ConfigMarket.java
@@ -95,8 +95,16 @@ public class ConfigMarket {
             StartingBalance = config.get(CURRENCY, "Starting Balance", 1000,
                 "Starting balance for new players (only used when Vault is not available)").getInt(1000);
 
-            MaxBalance = config.get(CURRENCY, "Maximum Balance", 999999999999L,
-                "Maximum balance a player can have (only used when Vault is not available)").getLong(999999999999L);
+            Property maxBalanceProp = config.get(CURRENCY, "Maximum Balance", String.valueOf(MaxBalance),
+                "Maximum balance a player can have (only used when Vault is not available)");
+            try {
+                MaxBalance = Long.parseLong(maxBalanceProp.getString());
+            } catch (NumberFormatException e) {
+                MaxBalance = 999999999999L;
+            }
+            if (MaxBalance < 0) {
+                MaxBalance = 0;
+            }
 
             // =========================================
             // Auction Settings

--- a/src/main/java/noppes/npcs/controllers/VaultHelper.java
+++ b/src/main/java/noppes/npcs/controllers/VaultHelper.java
@@ -4,7 +4,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import noppes.npcs.CustomNpcs;
 import noppes.npcs.config.ConfigMarket;
 import noppes.npcs.controllers.data.PlayerData;
-import noppes.npcs.controllers.data.PlayerDataController;
+import noppes.npcs.controllers.PlayerDataController;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/noppes/npcs/controllers/data/AuctionFilter.java
+++ b/src/main/java/noppes/npcs/controllers/data/AuctionFilter.java
@@ -107,6 +107,9 @@ public class AuctionFilter {
         if (listing == null) {
             return false;
         }
+        if (listing.item == null) {
+            return false;
+        }
 
         // Search text filter (case-insensitive)
         if (!searchText.isEmpty()) {
@@ -199,9 +202,13 @@ public class AuctionFilter {
         maxPrice = compound.getLong("MaxPrice");
         buyoutOnly = compound.getBoolean("BuyoutOnly");
         noBidsOnly = compound.getBoolean("NoBidsOnly");
-        page = compound.getInteger("Page");
+        page = Math.max(0, compound.getInteger("Page"));
         pageSize = compound.getInteger("PageSize");
-        if (pageSize <= 0) pageSize = 20;
+        if (pageSize <= 0) {
+            pageSize = 20;
+        } else {
+            pageSize = Math.min(100, pageSize);
+        }
         sellerUUID = compound.getString("SellerUUID");
         sellerName = compound.getString("SellerName");
     }

--- a/src/main/java/noppes/npcs/controllers/data/TraderStock.java
+++ b/src/main/java/noppes/npcs/controllers/data/TraderStock.java
@@ -58,6 +58,9 @@ public class TraderStock {
             return pStock.getStock(slot, maxStock[slot]);
         }
 
+        if (currentStock[slot] < 0) {
+            return maxStock[slot];
+        }
         return Math.max(0, currentStock[slot]);
     }
 
@@ -83,6 +86,9 @@ public class TraderStock {
             return pStock.consumeStock(slot, maxStock[slot], amount);
         }
 
+        if (currentStock[slot] < 0) {
+            currentStock[slot] = maxStock[slot];
+        }
         if (currentStock[slot] >= amount) {
             currentStock[slot] -= amount;
             return true;

--- a/src/main/java/noppes/npcs/roles/RoleAuctioneer.java
+++ b/src/main/java/noppes/npcs/roles/RoleAuctioneer.java
@@ -6,6 +6,7 @@ import noppes.npcs.NoppesUtilServer;
 import noppes.npcs.config.ConfigMarket;
 import noppes.npcs.constants.EnumGuiType;
 import noppes.npcs.controllers.AuctionController;
+import noppes.npcs.controllers.data.Line;
 import noppes.npcs.entity.EntityNPCInterface;
 
 /**
@@ -69,9 +70,9 @@ public class RoleAuctioneer extends RoleInterface {
         // Check if auction system is enabled
         if (!ConfigMarket.AuctionEnabled) {
             if (!noAuctionMessage.isEmpty()) {
-                npc.say(player, noAuctionMessage);
+                npc.say(player, new Line(noAuctionMessage));
             } else {
-                npc.say(player, "The auction house is currently closed.");
+                npc.say(player, new Line("The auction house is currently closed."));
             }
             return;
         }
@@ -83,7 +84,7 @@ public class RoleAuctioneer extends RoleInterface {
 
         // Say welcome message
         if (!welcomeMessage.isEmpty()) {
-            npc.say(player, welcomeMessage);
+            npc.say(player, new Line(welcomeMessage));
         } else {
             npc.say(player, npc.advanced.getInteractLine());
         }


### PR DESCRIPTION
### Motivation
- Prevent client/server desyncs and NPEs in auction/trader flows by validating client-provided data against server-side state.
- Ensure admin cancellations safely refund bidders and mark listings to avoid lost funds or items.
- Make GUI input and scroll handling robust to invalid/missing listing data and preserve server ordering in the UI.
- Fix configuration parsing/runtime issues and initialize trader stock state correctly on first use.

### Description
- Validate listing creation in `AuctionActionPacket` by comparing the client-sent NBT with the server `ContainerAuction` slot, use the container `ItemStack` for creation, and clear the slot after success.
- Tighten pagination and bounds in `AuctionController.getFilteredListings`, normalize the returned `currentPage`, skip null `item` entries in search/filter, and make name sorting safe via `getListingName` helper.
- Change `cancelListing` to `cancelListing(int, EntityPlayer, boolean)` to support admin-forced cancellations that refund bidders with `CurrencyController.addClaim` and mark listings `CANCELLED` safely.
- Harden GUI components: prevent actions when `listing.item` is null, adapt `GuiCustomScroll` listener method names, call `setList(displayList, true, false)` to preserve server order, switch numeric fields to `setIntegersOnly`, and add safe `Long.parseLong` helpers in `SubGuiAuctionCreate` and `SubGuiAuctionBid`.
- Fix `ConfigMarket` `MaxBalance` parsing to use `Property.getString()` and `Long.parseLong()` with fallback and clamp, initialize `TraderStock.currentStock` when unset, and wrap auctioneer speech with `Line` to match API types.

### Testing
- Ran `git submodule update --init --recursive` to fetch API sources and dependencies (successful).
- Ran `./gradlew updateAPI` which completed successfully.
- Built the project with `./gradlew build` which completed successfully and produced no compile errors.
- Compilation-aware GUI/controller fixes were validated by the build (no automated gameplay tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a4245462c83239715f5536c8fef59)