### PR TITLE
Refactor ability logic: remove vertical KB, add teleport modes, cutter/guard updates, collision & sounds

### DIFF
--- a/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityBeam.java
+++ b/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityBeam.java
@@ -169,7 +169,7 @@ public class AbilityBeam extends Ability {
                     if (isInBeamPath(livingEntity, startX, startY, startZ, dirX, dirZ)) {
                         hitThisTick.add(entity.getEntityId());
                         // Apply damage with scripted event support (no knockback for beam)
-                        applyAbilityDamage(npc, livingEntity, damage, 0, 0);
+                        applyAbilityDamage(npc, livingEntity, damage, 0);
 
                         if (!piercing) {
                             return; // Stop at first hit

--- a/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityDash.java
+++ b/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityDash.java
@@ -95,6 +95,8 @@ public class AbilityDash extends Ability {
         // No telegraph for dash - it's a quick evasive move
         this.telegraphType = TelegraphType.NONE;
         this.showTelegraph = false;
+        this.windUpSound = "mob.bat.takeoff";
+        this.activeSound = "mob.endermen.portal";
     }
 
     @Override
@@ -152,8 +154,6 @@ public class AbilityDash extends Ability {
             Math.cos(yawRad)
         );
 
-        // Play dash sound
-        world.playSoundAtEntity(npc, "mob.endermen.portal", 0.5f, 1.5f);
     }
 
     @Override
@@ -168,6 +168,13 @@ public class AbilityDash extends Ability {
 
         // Check if reached max distance
         if (distanceTraveled >= dashDistance) {
+            npc.motionX = 0;
+            npc.motionZ = 0;
+            npc.velocityChanged = true;
+            return;
+        }
+
+        if (isDashBlocked(npc)) {
             npc.motionX = 0;
             npc.motionZ = 0;
             npc.velocityChanged = true;
@@ -200,6 +207,12 @@ public class AbilityDash extends Ability {
         npc.velocityChanged = true;
         dashDirection = null;
         chosenDirection = null;
+    }
+
+    private boolean isDashBlocked(EntityNPCInterface npc) {
+        double nextX = dashDirection.xCoord * dashSpeed;
+        double nextZ = dashDirection.zCoord * dashSpeed;
+        return !npc.worldObj.getCollidingBoundingBoxes(npc, npc.boundingBox.copy().offset(nextX, 0, nextZ)).isEmpty();
     }
 
     @Override

--- a/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityHazard.java
+++ b/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityHazard.java
@@ -290,7 +290,7 @@ public class AbilityHazard extends Ability {
                         entity.hurtResistantTime = 0;
                     }
                     // Apply damage with scripted event support (no knockback for hazard ticks)
-                    boolean wasHit = applyAbilityDamage(npc, entity, damagePerTick, 0, 0);
+                    boolean wasHit = applyAbilityDamage(npc, entity, damagePerTick, 0);
                     if (!wasHit) continue; // Skip debuffs if hit was cancelled
                 }
 

--- a/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityHeavyHit.java
+++ b/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityHeavyHit.java
@@ -24,8 +24,9 @@ public class AbilityHeavyHit extends Ability {
 
     private float damage = 15.0f;
     private float knockback = 2.0f;
-    private float knockbackUp = 0.3f;
-    private int stunTicks = 40;
+    private int slownessLevel = 1;
+    private int weaknessLevel = 0;
+    private int potionDurationSeconds = 2;
 
     public AbilityHeavyHit() {
         this.typeId = "ability.cnpc.heavy_hit";
@@ -40,6 +41,8 @@ public class AbilityHeavyHit extends Ability {
         this.recoveryTicks = 20;
         this.telegraphType = TelegraphType.POINT;
         this.showTelegraph = false;
+        this.windUpSound = "random.anvil_use";
+        this.activeSound = "random.anvil_land";
     }
 
     @Override
@@ -65,12 +68,16 @@ public class AbilityHeavyHit extends Ability {
         if (world.isRemote || target == null) return;
 
         // Apply damage with scripted event support
-        boolean wasHit = applyAbilityDamage(npc, target, damage, knockback, knockbackUp);
+        boolean wasHit = applyAbilityDamage(npc, target, damage, knockback);
 
-        // Apply stun (slowness + weakness) if the hit wasn't cancelled
-        if (wasHit && stunTicks > 0) {
-            target.addPotionEffect(new PotionEffect(Potion.moveSlowdown.id, stunTicks, 10));
-            target.addPotionEffect(new PotionEffect(Potion.weakness.id, stunTicks, 2));
+        if (wasHit && potionDurationSeconds > 0) {
+            int durationTicks = potionDurationSeconds * 20;
+            if (slownessLevel >= 0) {
+                target.addPotionEffect(new PotionEffect(Potion.moveSlowdown.id, durationTicks, slownessLevel));
+            }
+            if (weaknessLevel >= 0) {
+                target.addPotionEffect(new PotionEffect(Potion.weakness.id, durationTicks, weaknessLevel));
+            }
         }
     }
 
@@ -83,16 +90,18 @@ public class AbilityHeavyHit extends Ability {
     public void writeTypeNBT(NBTTagCompound nbt) {
         nbt.setFloat("damage", damage);
         nbt.setFloat("knockback", knockback);
-        nbt.setFloat("knockbackUp", knockbackUp);
-        nbt.setInteger("stunTicks", stunTicks);
+        nbt.setInteger("slownessLevel", slownessLevel);
+        nbt.setInteger("weaknessLevel", weaknessLevel);
+        nbt.setInteger("potionDurationSeconds", potionDurationSeconds);
     }
 
     @Override
     public void readTypeNBT(NBTTagCompound nbt) {
         this.damage = nbt.hasKey("damage") ? nbt.getFloat("damage") : 15.0f;
         this.knockback = nbt.hasKey("knockback") ? nbt.getFloat("knockback") : 2.0f;
-        this.knockbackUp = nbt.hasKey("knockbackUp") ? nbt.getFloat("knockbackUp") : 0.3f;
-        this.stunTicks = nbt.hasKey("stunTicks") ? nbt.getInteger("stunTicks") : 40;
+        this.slownessLevel = nbt.hasKey("slownessLevel") ? nbt.getInteger("slownessLevel") : 1;
+        this.weaknessLevel = nbt.hasKey("weaknessLevel") ? nbt.getInteger("weaknessLevel") : 0;
+        this.potionDurationSeconds = nbt.hasKey("potionDurationSeconds") ? nbt.getInteger("potionDurationSeconds") : 2;
     }
 
     // Getters & Setters
@@ -102,9 +111,12 @@ public class AbilityHeavyHit extends Ability {
     public float getKnockback() { return knockback; }
     public void setKnockback(float knockback) { this.knockback = knockback; }
 
-    public float getKnockbackUp() { return knockbackUp; }
-    public void setKnockbackUp(float knockbackUp) { this.knockbackUp = knockbackUp; }
+    public int getSlownessLevel() { return slownessLevel; }
+    public void setSlownessLevel(int slownessLevel) { this.slownessLevel = slownessLevel; }
 
-    public int getStunTicks() { return stunTicks; }
-    public void setStunTicks(int stunTicks) { this.stunTicks = stunTicks; }
+    public int getWeaknessLevel() { return weaknessLevel; }
+    public void setWeaknessLevel(int weaknessLevel) { this.weaknessLevel = weaknessLevel; }
+
+    public int getPotionDurationSeconds() { return potionDurationSeconds; }
+    public void setPotionDurationSeconds(int potionDurationSeconds) { this.potionDurationSeconds = potionDurationSeconds; }
 }

--- a/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityOrb.java
+++ b/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityOrb.java
@@ -194,7 +194,7 @@ public class AbilityOrb extends Ability {
                 doExplosion(npc, world);
             } else {
                 // Apply damage with scripted event support
-                boolean wasHit = applyAbilityDamage(npc, entity, damage, knockback, 0.2f);
+                boolean wasHit = applyAbilityDamage(npc, entity, damage, knockback);
                 if (wasHit) {
                     applyEffects(entity);
                 }
@@ -231,7 +231,7 @@ public class AbilityOrb extends Ability {
             if (dist <= explosionRadius) {
                 float falloff = 1.0f - (float)(dist / explosionRadius) * explosionDamageFalloff;
                 // Apply damage with scripted event support
-                boolean wasHit = applyAbilityDamage(npc, blastTarget, damage * falloff, knockback * falloff, 0.3f);
+                boolean wasHit = applyAbilityDamage(npc, blastTarget, damage * falloff, knockback * falloff);
                 if (wasHit) {
                     applyEffects(blastTarget);
                 }

--- a/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityProjectile.java
+++ b/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityProjectile.java
@@ -83,7 +83,7 @@ public class AbilityProjectile extends Ability {
 
         // Deal instant damage with scripted event support
         // TODO: Use custom EntityAbilityProjectile for actual tracking
-        applyAbilityDamageWithDirection(npc, target, damage, knockback, 0.1f, dx, dz);
+        applyAbilityDamageWithDirection(npc, target, damage, knockback, dx, dz);
 
         // Play sound
         world.playSoundAtEntity(npc, "random.bow", 1.0f, 0.8f);
@@ -101,7 +101,7 @@ public class AbilityProjectile extends Ability {
                     if (dist < explosionRadius) {
                         float falloff = 1.0f - (dist / explosionRadius);
                         // Apply splash damage with scripted event support (no knockback)
-                        applyAbilityDamage(npc, living, damage * falloff * 0.5f, 0, 0);
+                        applyAbilityDamage(npc, living, damage * falloff * 0.5f, 0);
                     }
                 }
             }

--- a/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityShockwave.java
+++ b/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityShockwave.java
@@ -27,11 +27,9 @@ public class AbilityShockwave extends Ability {
 
     private float pushRadius = 8.0f;
     private float pushStrength = 1.5f;
-    private float pushUp = 0.5f;
     private float damage = 10.0f;
     private int stunDuration = 0;
     private int maxTargets = 10;
-    private boolean aoe = true;
 
     // Runtime state
     private transient boolean executed = false;
@@ -47,6 +45,8 @@ public class AbilityShockwave extends Ability {
         this.activeTicks = 5;
         this.recoveryTicks = 20;
         this.telegraphType = TelegraphType.CIRCLE;
+        this.windUpSound = "random.explode";
+        this.activeSound = "random.explode";
     }
 
     @Override
@@ -78,9 +78,6 @@ public class AbilityShockwave extends Ability {
     public void onActiveTick(EntityNPCInterface npc, EntityLivingBase target, World world, int tick) {
         if (executed) return;
         executed = true;
-
-        // Play shockwave sound
-        world.playSoundAtEntity(npc, "random.explode", 0.5f, 1.5f);
 
         // Get all entities in radius
         AxisAlignedBB box = npc.boundingBox.expand(pushRadius, pushRadius / 2, pushRadius);
@@ -116,10 +113,8 @@ public class AbilityShockwave extends Ability {
             // Scale knockback by distance (closer = stronger)
             float distFactor = 1.0f - (float)(dist / pushRadius) * 0.5f;
             float finalPush = pushStrength * distFactor;
-            float finalPushUp = pushUp * distFactor;
-
             // Apply damage with custom knockback direction
-            boolean wasHit = applyAbilityDamageWithDirection(npc, entity, damage * distFactor, finalPush, finalPushUp, dx, dz);
+            boolean wasHit = applyAbilityDamageWithDirection(npc, entity, damage * distFactor, finalPush, dx, dz);
 
             // Apply stun if hit connected
             if (wasHit && stunDuration > 0) {
@@ -143,22 +138,18 @@ public class AbilityShockwave extends Ability {
     public void writeTypeNBT(NBTTagCompound nbt) {
         nbt.setFloat("pushRadius", pushRadius);
         nbt.setFloat("pushStrength", pushStrength);
-        nbt.setFloat("pushUp", pushUp);
         nbt.setFloat("damage", damage);
         nbt.setInteger("stunDuration", stunDuration);
         nbt.setInteger("maxTargets", maxTargets);
-        nbt.setBoolean("aoe", aoe);
     }
 
     @Override
     public void readTypeNBT(NBTTagCompound nbt) {
         this.pushRadius = nbt.hasKey("pushRadius") ? nbt.getFloat("pushRadius") : 8.0f;
         this.pushStrength = nbt.hasKey("pushStrength") ? nbt.getFloat("pushStrength") : 1.5f;
-        this.pushUp = nbt.hasKey("pushUp") ? nbt.getFloat("pushUp") : 0.5f;
         this.damage = nbt.hasKey("damage") ? nbt.getFloat("damage") : 10.0f;
         this.stunDuration = nbt.hasKey("stunDuration") ? nbt.getInteger("stunDuration") : 0;
         this.maxTargets = nbt.hasKey("maxTargets") ? nbt.getInteger("maxTargets") : 10;
-        this.aoe = !nbt.hasKey("aoe") || nbt.getBoolean("aoe");
     }
 
     // Getters & Setters
@@ -167,9 +158,6 @@ public class AbilityShockwave extends Ability {
 
     public float getPushStrength() { return pushStrength; }
     public void setPushStrength(float pushStrength) { this.pushStrength = pushStrength; }
-
-    public float getPushUp() { return pushUp; }
-    public void setPushUp(float pushUp) { this.pushUp = pushUp; }
 
     public float getDamage() { return damage; }
     public void setDamage(float damage) { this.damage = damage; }
@@ -180,6 +168,4 @@ public class AbilityShockwave extends Ability {
     public int getMaxTargets() { return maxTargets; }
     public void setMaxTargets(int maxTargets) { this.maxTargets = maxTargets; }
 
-    public boolean isAoe() { return aoe; }
-    public void setAoe(boolean aoe) { this.aoe = aoe; }
 }

--- a/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilitySlam.java
+++ b/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilitySlam.java
@@ -36,8 +36,7 @@ public class AbilitySlam extends Ability {
     private float radius = 5.0f;
     private float knockbackStrength = 1.5f;
     private float leapSpeed = 1.0f;
-    private float minLeapDistance = 2.0f;
-    private float maxLeapDistance = 15.0f;
+    private float leapHeight = 4.0f;
 
     // Runtime state
     private transient double targetX, targetY, targetZ;
@@ -58,6 +57,8 @@ public class AbilitySlam extends Ability {
         this.minRange = 2.0f;
         this.maxRange = 15.0f;
         this.telegraphType = TelegraphType.CIRCLE;
+        this.windUpSound = "mob.irongolem.throw";
+        this.activeSound = "random.explode";
     }
 
     @Override
@@ -157,11 +158,11 @@ public class AbilitySlam extends Ability {
         }
 
         // Cap the distance if too far
-        if (horizontalDist > maxLeapDistance) {
-            double scale = maxLeapDistance / horizontalDist;
+        if (horizontalDist > maxRange) {
+            double scale = maxRange / horizontalDist;
             dx *= scale;
             dz *= scale;
-            horizontalDist = maxLeapDistance;
+            horizontalDist = maxRange;
             targetX = npc.posX + dx;
             targetZ = npc.posZ + dz;
         }
@@ -188,7 +189,7 @@ public class AbilitySlam extends Ability {
 
         // Calculate required upward velocity to create a nice arc and land at target height
         // Peak height should be proportional to horizontal distance for visual appeal
-        double arcHeight = Math.max(3.0, horizontalDist * 0.3) * leapSpeed;
+        double arcHeight = Math.max(1.0, leapHeight) * leapSpeed;
 
         // Approximate the required initial vertical velocity
         // Account for gravity and drag - use a simplified model
@@ -222,8 +223,6 @@ public class AbilitySlam extends Ability {
         npc.rotationYaw = targetYaw;
         npc.rotationYawHead = targetYaw;
 
-        // Play launch sound
-        npc.worldObj.playSoundAtEntity(npc, "mob.irongolem.throw", 0.8f, 0.8f);
     }
 
     @Override
@@ -287,14 +286,11 @@ public class AbilitySlam extends Ability {
                 double dx = livingTarget.posX - npc.posX;
                 double dz = livingTarget.posZ - npc.posZ;
                 if (dx * dx + dz * dz <= radius * radius) {
-                    // Apply damage with scripted event support (0.3f is the upward knockback boost)
-                    applyAbilityDamage(npc, livingTarget, damage, knockbackStrength, 0.3f);
+                    // Apply damage with scripted event support
+                    applyAbilityDamage(npc, livingTarget, damage, knockbackStrength);
                 }
             }
         }
-
-        // Play impact sound
-        world.playSoundAtEntity(npc, "random.explode", 0.5f, 1.2f);
 
         // Spawn particles
         spawnSlamParticles(world, npc.posX, npc.posY, npc.posZ);
@@ -418,8 +414,7 @@ public class AbilitySlam extends Ability {
         nbt.setFloat("radius", radius);
         nbt.setFloat("knockback", knockbackStrength);
         nbt.setFloat("leapSpeed", leapSpeed);
-        nbt.setFloat("minLeapDistance", minLeapDistance);
-        nbt.setFloat("maxLeapDistance", maxLeapDistance);
+        nbt.setFloat("leapHeight", leapHeight);
     }
 
     @Override
@@ -428,8 +423,7 @@ public class AbilitySlam extends Ability {
         radius = nbt.hasKey("radius") ? nbt.getFloat("radius") : 5.0f;
         knockbackStrength = nbt.hasKey("knockback") ? nbt.getFloat("knockback") : 1.5f;
         leapSpeed = nbt.hasKey("leapSpeed") ? nbt.getFloat("leapSpeed") : 1.0f;
-        minLeapDistance = nbt.hasKey("minLeapDistance") ? nbt.getFloat("minLeapDistance") : 2.0f;
-        maxLeapDistance = nbt.hasKey("maxLeapDistance") ? nbt.getFloat("maxLeapDistance") : 15.0f;
+        leapHeight = nbt.hasKey("leapHeight") ? nbt.getFloat("leapHeight") : 4.0f;
     }
 
     // Getters & Setters
@@ -445,9 +439,6 @@ public class AbilitySlam extends Ability {
     public float getLeapSpeed() { return leapSpeed; }
     public void setLeapSpeed(float leapSpeed) { this.leapSpeed = leapSpeed; }
 
-    public float getMinLeapDistance() { return minLeapDistance; }
-    public void setMinLeapDistance(float minLeapDistance) { this.minLeapDistance = minLeapDistance; }
-
-    public float getMaxLeapDistance() { return maxLeapDistance; }
-    public void setMaxLeapDistance(float maxLeapDistance) { this.maxLeapDistance = maxLeapDistance; }
+    public float getLeapHeight() { return leapHeight; }
+    public void setLeapHeight(float leapHeight) { this.leapHeight = leapHeight; }
 }

--- a/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityTrap.java
+++ b/src/main/java/kamkeel/npcs/controllers/data/ability/type/AbilityTrap.java
@@ -45,7 +45,6 @@ public class AbilityTrap extends Ability {
     private float damage = 10.0f;
     private float damageRadius = 0.0f;
     private float knockback = 0.5f;
-    private float knockbackUp = 0.3f;
     private int stunDuration = 0;
     private int rootDuration = 40;
     private int slowDuration = 0;
@@ -274,7 +273,7 @@ public class AbilityTrap extends Ability {
 
         for (EntityLivingBase entity : affected) {
             // Apply damage with scripted event support
-            boolean wasHit = applyAbilityDamage(npc, entity, damage, knockback, knockbackUp);
+            boolean wasHit = applyAbilityDamage(npc, entity, damage, knockback);
 
             // Only apply effects if the hit wasn't cancelled
             if (wasHit) {
@@ -323,7 +322,6 @@ public class AbilityTrap extends Ability {
         nbt.setFloat("damage", damage);
         nbt.setFloat("damageRadius", damageRadius);
         nbt.setFloat("knockback", knockback);
-        nbt.setFloat("knockbackUp", knockbackUp);
         nbt.setInteger("stunDuration", stunDuration);
         nbt.setInteger("rootDuration", rootDuration);
         nbt.setInteger("slowDuration", slowDuration);
@@ -351,7 +349,6 @@ public class AbilityTrap extends Ability {
         this.damage = nbt.hasKey("damage") ? nbt.getFloat("damage") : 10.0f;
         this.damageRadius = nbt.hasKey("damageRadius") ? nbt.getFloat("damageRadius") : 0.0f;
         this.knockback = nbt.hasKey("knockback") ? nbt.getFloat("knockback") : 0.5f;
-        this.knockbackUp = nbt.hasKey("knockbackUp") ? nbt.getFloat("knockbackUp") : 0.3f;
         this.stunDuration = nbt.hasKey("stunDuration") ? nbt.getInteger("stunDuration") : 0;
         this.rootDuration = nbt.hasKey("rootDuration") ? nbt.getInteger("rootDuration") : 40;
         this.slowDuration = nbt.hasKey("slowDuration") ? nbt.getInteger("slowDuration") : 0;
@@ -391,9 +388,6 @@ public class AbilityTrap extends Ability {
 
     public float getKnockback() { return knockback; }
     public void setKnockback(float knockback) { this.knockback = knockback; }
-
-    public float getKnockbackUp() { return knockbackUp; }
-    public void setKnockbackUp(float knockbackUp) { this.knockbackUp = knockbackUp; }
 
     public int getStunDuration() { return stunDuration; }
     public void setStunDuration(int stunDuration) { this.stunDuration = stunDuration; }

--- a/src/main/java/noppes/npcs/DataAbilities.java
+++ b/src/main/java/noppes/npcs/DataAbilities.java
@@ -537,7 +537,7 @@ public class DataAbilities {
      * @param hitEntity The entity being hit
      * @param damage The damage amount
      * @param knockback The horizontal knockback
-     * @param knockbackUp The vertical knockback
+     * @param knockbackUp The vertical knockback (deprecated, ignored)
      * @return The event (with possibly modified values), or null if cancelled
      */
     public AbilityEvent.HitEvent fireHitEvent(Ability ability, EntityLivingBase target,

--- a/src/main/java/noppes/npcs/ai/CombatHandler.java
+++ b/src/main/java/noppes/npcs/ai/CombatHandler.java
@@ -79,6 +79,15 @@ public class CombatHandler {
             aggressors.put(el, f + damageAmount);
         }
 
+        // Handle guard counter before interruption
+        if (npc.abilities.getCurrentAbility() instanceof kamkeel.npcs.controllers.data.ability.type.AbilityGuard) {
+            kamkeel.npcs.controllers.data.ability.type.AbilityGuard guard =
+                (kamkeel.npcs.controllers.data.ability.type.AbilityGuard) npc.abilities.getCurrentAbility();
+            if (guard.isGuarding() && e instanceof EntityLivingBase) {
+                guard.onDamageTaken(npc, (EntityLivingBase) e, source, damageAmount);
+            }
+        }
+
         // Check for ability interruption
         npc.abilities.onDamage(source, damageAmount);
     }

--- a/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityCharge.java
+++ b/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityCharge.java
@@ -35,21 +35,16 @@ public class SubGuiAbilityCharge extends SubGuiAbilityConfig {
 
         y += 24;
 
-        // Row 2: Knockback + Knockback Up
+        // Row 2: Knockback
         addLabel(new GuiNpcLabel(102, "ability.knockback", labelX, y + 5));
         addTextField(createFloatField(102, fieldX, y, 50, charge.getKnockback()));
 
-        addLabel(new GuiNpcLabel(103, "ability.knockbackUp", col2LabelX, y + 5));
-        addTextField(createFloatField(103, col2FieldX, y, 50, charge.getKnockbackUp()));
-
         y += 24;
 
-        // Row 3: Max Distance + Hit Radius
-        addLabel(new GuiNpcLabel(104, "ability.maxDist", labelX, y + 5));
-        addTextField(createFloatField(104, fieldX, y, 50, charge.getMaxDistance()));
+        // Row 3: Hit Width
+        addLabel(new GuiNpcLabel(104, "ability.hitWidth", labelX, y + 5));
+        addTextField(createFloatField(104, fieldX, y, 50, charge.getHitWidth()));
 
-        addLabel(new GuiNpcLabel(105, "ability.hitRadius", col2LabelX, y + 5));
-        addTextField(createFloatField(105, col2FieldX, y, 50, charge.getHitRadius()));
     }
 
     @Override
@@ -58,9 +53,7 @@ public class SubGuiAbilityCharge extends SubGuiAbilityConfig {
             case 100: charge.setDamage(parseFloat(field, charge.getDamage())); break;
             case 101: charge.setChargeSpeed(parseFloat(field, charge.getChargeSpeed())); break;
             case 102: charge.setKnockback(parseFloat(field, charge.getKnockback())); break;
-            case 103: charge.setKnockbackUp(parseFloat(field, charge.getKnockbackUp())); break;
-            case 104: charge.setMaxDistance(parseFloat(field, charge.getMaxDistance())); break;
-            case 105: charge.setHitRadius(parseFloat(field, charge.getHitRadius())); break;
+            case 104: charge.setHitWidth(parseFloat(field, charge.getHitWidth())); break;
         }
     }
 }

--- a/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityCutter.java
+++ b/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityCutter.java
@@ -45,18 +45,18 @@ public class SubGuiAbilityCutter extends SubGuiAbilityConfig {
 
         y += 24;
 
-        // Row 3: Knockback + Knockback Up
+        // Row 3: Knockback + Sweep Speed
         addLabel(new GuiNpcLabel(104, "ability.knockback", labelX, y + 5));
         addTextField(createFloatField(104, fieldX, y, 50, cutter.getKnockback()));
 
-        addLabel(new GuiNpcLabel(105, "ability.knockbackUp", col2LabelX, y + 5));
-        addTextField(createFloatField(105, col2FieldX, y, 50, cutter.getKnockbackUp()));
+        addLabel(new GuiNpcLabel(105, "ability.sweepSpeed", col2LabelX, y + 5));
+        addTextField(createFloatField(105, col2FieldX, y, 50, cutter.getSweepSpeed()));
 
         y += 24;
 
         // Row 4: Sweep Mode + Piercing
         addLabel(new GuiNpcLabel(106, "ability.sweepMode", labelX, y + 5));
-        String[] sweepModes = {"Instant", "Expanding", "Rotating"};
+        String[] sweepModes = {"Swipe", "Spin"};
         addButton(new GuiNpcButton(106, fieldX, y, 70, 20, sweepModes, cutter.getSweepMode().ordinal()));
 
         addLabel(new GuiNpcLabel(107, "ability.piercing", col2LabelX, y + 5));
@@ -64,12 +64,18 @@ public class SubGuiAbilityCutter extends SubGuiAbilityConfig {
 
         y += 24;
 
-        // Row 5: Stun Duration + Bleed Duration
+        // Row 5: Stun Duration + Poison Time
         addLabel(new GuiNpcLabel(108, "ability.stunDuration", labelX, y + 5));
         addTextField(createIntField(108, fieldX, y, 50, cutter.getStunDuration()));
 
-        addLabel(new GuiNpcLabel(109, "ability.bleedDuration", col2LabelX, y + 5));
-        addTextField(createIntField(109, col2FieldX, y, 50, cutter.getBleedDuration()));
+        addLabel(new GuiNpcLabel(109, "ability.poisonTime", col2LabelX, y + 5));
+        addTextField(createIntField(109, col2FieldX, y, 50, cutter.getPoisonDurationSeconds()));
+
+        y += 24;
+
+        // Row 6: Poison Level
+        addLabel(new GuiNpcLabel(110, "ability.poisonLvl", labelX, y + 5));
+        addTextField(createIntField(110, fieldX, y, 50, cutter.getPoisonLevel()));
     }
 
     @Override
@@ -89,9 +95,10 @@ public class SubGuiAbilityCutter extends SubGuiAbilityConfig {
             case 102: cutter.setArcAngle(parseFloat(field, cutter.getArcAngle())); break;
             case 103: cutter.setInnerRadius(parseFloat(field, cutter.getInnerRadius())); break;
             case 104: cutter.setKnockback(parseFloat(field, cutter.getKnockback())); break;
-            case 105: cutter.setKnockbackUp(parseFloat(field, cutter.getKnockbackUp())); break;
+            case 105: cutter.setSweepSpeed(parseFloat(field, cutter.getSweepSpeed())); break;
             case 108: cutter.setStunDuration(field.getInteger()); break;
-            case 109: cutter.setBleedDuration(field.getInteger()); break;
+            case 109: cutter.setPoisonDurationSeconds(field.getInteger()); break;
+            case 110: cutter.setPoisonLevel(field.getInteger()); break;
         }
     }
 }

--- a/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityGuard.java
+++ b/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityGuard.java
@@ -28,34 +28,58 @@ public class SubGuiAbilityGuard extends SubGuiAbilityConfig {
         int col2FieldX = guiLeft + 225;
 
         // Row 1: Damage Reduction
-        addLabel(new GuiNpcLabel(100, "ability.dmgReduction", labelX, y + 5));
+        addLabel(new GuiNpcLabel(100, "ability.dmgReduce", labelX, y + 5));
         addTextField(createFloatField(100, fieldX, y, 50, guard.getDamageReduction()));
 
         y += 24;
 
-        // Row 2: Can Counter + Counter Damage
+        // Row 2: Can Counter + Counter Type
         addLabel(new GuiNpcLabel(101, "ability.canCounter", labelX, y + 5));
         addButton(new GuiNpcButton(101, fieldX, y, 50, 20, new String[]{"gui.no", "gui.yes"}, guard.isCanCounter() ? 1 : 0));
 
-        addLabel(new GuiNpcLabel(102, "ability.counterDmg", col2LabelX, y + 5));
-        GuiNpcTextField counterDmgField = createFloatField(102, col2FieldX, y, 40, guard.getCounterDamage());
-        counterDmgField.setEnabled(guard.isCanCounter());
-        addTextField(counterDmgField);
+        addLabel(new GuiNpcLabel(102, "ability.counterType", col2LabelX, y + 5));
+        String[] types = {"Flat", "Percent"};
+        GuiNpcButton counterTypeButton = new GuiNpcButton(102, col2FieldX, y, 60, 20, types, guard.getCounterType().ordinal());
+        counterTypeButton.setEnabled(guard.isCanCounter());
+        addButton(counterTypeButton);
 
         y += 24;
 
-        // Row 3: Counter Chance
-        addLabel(new GuiNpcLabel(103, "ability.counterChance", labelX, y + 5));
-        GuiNpcTextField counterChanceField = createFloatField(103, fieldX, y, 50, guard.getCounterChance());
+        // Row 3: Counter Value + Counter Chance
+        addLabel(new GuiNpcLabel(103, "ability.counterValue", labelX, y + 5));
+        GuiNpcTextField counterValueField = createFloatField(103, fieldX, y, 50, guard.getCounterValue());
+        counterValueField.setEnabled(guard.isCanCounter());
+        addTextField(counterValueField);
+
+        addLabel(new GuiNpcLabel(104, "ability.counterChance", col2LabelX, y + 5));
+        GuiNpcTextField counterChanceField = createFloatField(104, col2FieldX, y, 50, guard.getCounterChance());
         counterChanceField.setEnabled(guard.isCanCounter());
         addTextField(counterChanceField);
+
+        y += 24;
+
+        // Row 4: Counter Sound + Counter Animation
+        addLabel(new GuiNpcLabel(105, "ability.counterSound", labelX, y + 5));
+        GuiNpcTextField counterSoundField = new GuiNpcTextField(105, this, fontRendererObj, fieldX, y, 100, 20, guard.getCounterSound());
+        counterSoundField.setEnabled(guard.isCanCounter());
+        addTextField(counterSoundField);
+
+        addLabel(new GuiNpcLabel(106, "ability.counterAnim", col2LabelX, y + 5));
+        GuiNpcTextField counterAnimField = createIntField(106, col2FieldX, y, 50, guard.getCounterAnimationId());
+        counterAnimField.setEnabled(guard.isCanCounter());
+        addTextField(counterAnimField);
     }
 
     @Override
     protected void handleTypeButton(int id, GuiNpcButton button) {
-        if (id == 101) {
-            guard.setCanCounter(button.getValue() == 1);
-            initGui();
+        switch (id) {
+            case 101:
+                guard.setCanCounter(button.getValue() == 1);
+                initGui();
+                break;
+            case 102:
+                guard.setCounterType(AbilityGuard.CounterType.values()[button.getValue()]);
+                break;
         }
     }
 
@@ -63,8 +87,10 @@ public class SubGuiAbilityGuard extends SubGuiAbilityConfig {
     protected void handleTypeTextField(int id, GuiNpcTextField field) {
         switch (id) {
             case 100: guard.setDamageReduction(parseFloat(field, guard.getDamageReduction())); break;
-            case 102: guard.setCounterDamage(parseFloat(field, guard.getCounterDamage())); break;
-            case 103: guard.setCounterChance(parseFloat(field, guard.getCounterChance())); break;
+            case 103: guard.setCounterValue(parseFloat(field, guard.getCounterValue())); break;
+            case 104: guard.setCounterChance(parseFloat(field, guard.getCounterChance())); break;
+            case 105: guard.setCounterSound(field.getText()); break;
+            case 106: guard.setCounterAnimationId(field.getInteger()); break;
         }
     }
 }

--- a/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityHeavyHit.java
+++ b/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityHeavyHit.java
@@ -26,30 +26,37 @@ public class SubGuiAbilityHeavyHit extends SubGuiAbilityConfig {
         int col2LabelX = guiLeft + 145;
         int col2FieldX = guiLeft + 205;
 
-        // Row 1: Damage + Stun Ticks
+        // Row 1: Damage + Potion Time
         addLabel(new GuiNpcLabel(100, "ability.damage", labelX, y + 5));
         addTextField(createFloatField(100, fieldX, y, 50, heavyHit.getDamage()));
 
-        addLabel(new GuiNpcLabel(101, "ability.stunTicks", col2LabelX, y + 5));
-        addTextField(createIntField(101, col2FieldX, y, 50, heavyHit.getStunTicks()));
+        addLabel(new GuiNpcLabel(101, "ability.potionTime", col2LabelX, y + 5));
+        addTextField(createIntField(101, col2FieldX, y, 50, heavyHit.getPotionDurationSeconds()));
 
         y += 24;
 
-        // Row 2: Knockback + Knockback Up
+        // Row 2: Knockback + Slowness Level
         addLabel(new GuiNpcLabel(102, "ability.knockback", labelX, y + 5));
         addTextField(createFloatField(102, fieldX, y, 50, heavyHit.getKnockback()));
 
-        addLabel(new GuiNpcLabel(103, "ability.knockbackUp", col2LabelX, y + 5));
-        addTextField(createFloatField(103, col2FieldX, y, 50, heavyHit.getKnockbackUp()));
+        addLabel(new GuiNpcLabel(103, "ability.slownessLvl", col2LabelX, y + 5));
+        addTextField(createIntField(103, col2FieldX, y, 50, heavyHit.getSlownessLevel()));
+
+        y += 24;
+
+        // Row 3: Weakness Level
+        addLabel(new GuiNpcLabel(104, "ability.weaknessLvl", labelX, y + 5));
+        addTextField(createIntField(104, fieldX, y, 50, heavyHit.getWeaknessLevel()));
     }
 
     @Override
     protected void handleTypeTextField(int id, GuiNpcTextField field) {
         switch (id) {
             case 100: heavyHit.setDamage(parseFloat(field, heavyHit.getDamage())); break;
-            case 101: heavyHit.setStunTicks(field.getInteger()); break;
+            case 101: heavyHit.setPotionDurationSeconds(field.getInteger()); break;
             case 102: heavyHit.setKnockback(parseFloat(field, heavyHit.getKnockback())); break;
-            case 103: heavyHit.setKnockbackUp(parseFloat(field, heavyHit.getKnockbackUp())); break;
+            case 103: heavyHit.setSlownessLevel(field.getInteger()); break;
+            case 104: heavyHit.setWeaknessLevel(field.getInteger()); break;
         }
     }
 }

--- a/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityShockwave.java
+++ b/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityShockwave.java
@@ -3,7 +3,6 @@ package noppes.npcs.client.gui.advanced.ability;
 import kamkeel.npcs.controllers.data.ability.type.AbilityShockwave;
 import noppes.npcs.client.gui.util.IAbilityConfigCallback;
 import noppes.npcs.client.gui.advanced.SubGuiAbilityConfig;
-import noppes.npcs.client.gui.util.GuiNpcButton;
 import noppes.npcs.client.gui.util.GuiNpcLabel;
 import noppes.npcs.client.gui.util.GuiNpcTextField;
 
@@ -36,21 +35,21 @@ public class SubGuiAbilityShockwave extends SubGuiAbilityConfig {
 
         y += 24;
 
-        // Row 2: Push Strength + Push Up
+        // Row 2: Push Strength
         addLabel(new GuiNpcLabel(102, "ability.pushStrength", labelX, y + 5));
         addTextField(createFloatField(102, fieldX, y, 50, shockwave.getPushStrength()));
-
-        addLabel(new GuiNpcLabel(103, "ability.pushUp", col2LabelX, y + 5));
-        addTextField(createFloatField(103, col2FieldX, y, 50, shockwave.getPushUp()));
 
         y += 24;
 
         // Row 3: Stun Duration + Max Targets
-        addLabel(new GuiNpcLabel(104, "ability.stunDuration", labelX, y + 5));
-        addTextField(createIntField(104, fieldX, y, 50, shockwave.getStunDuration()));
+        addLabel(new GuiNpcLabel(103, "ability.stunDuration", labelX, y + 5));
+        addTextField(createIntField(103, fieldX, y, 50, shockwave.getStunDuration()));
 
-        addLabel(new GuiNpcLabel(105, "ability.maxTargets", col2LabelX, y + 5));
-        addTextField(createIntField(105, col2FieldX, y, 50, shockwave.getMaxTargets()));
+        addLabel(new GuiNpcLabel(104, "ability.maxTargets", col2LabelX, y + 5));
+        addTextField(createIntField(104, col2FieldX, y, 50, shockwave.getMaxTargets()));
+
+        y += 24;
+        addLabel(new GuiNpcLabel(105, "ability.shockwaveFalloff", labelX, y + 5));
     }
 
     @Override
@@ -59,9 +58,8 @@ public class SubGuiAbilityShockwave extends SubGuiAbilityConfig {
             case 100: shockwave.setDamage(parseFloat(field, shockwave.getDamage())); break;
             case 101: shockwave.setPushRadius(parseFloat(field, shockwave.getPushRadius())); break;
             case 102: shockwave.setPushStrength(parseFloat(field, shockwave.getPushStrength())); break;
-            case 103: shockwave.setPushUp(parseFloat(field, shockwave.getPushUp())); break;
-            case 104: shockwave.setStunDuration(field.getInteger()); break;
-            case 105: shockwave.setMaxTargets(field.getInteger()); break;
+            case 103: shockwave.setStunDuration(field.getInteger()); break;
+            case 104: shockwave.setMaxTargets(field.getInteger()); break;
         }
     }
 }

--- a/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilitySlam.java
+++ b/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilitySlam.java
@@ -3,7 +3,6 @@ package noppes.npcs.client.gui.advanced.ability;
 import kamkeel.npcs.controllers.data.ability.type.AbilitySlam;
 import noppes.npcs.client.gui.util.IAbilityConfigCallback;
 import noppes.npcs.client.gui.advanced.SubGuiAbilityConfig;
-import noppes.npcs.client.gui.util.GuiNpcButton;
 import noppes.npcs.client.gui.util.GuiNpcLabel;
 import noppes.npcs.client.gui.util.GuiNpcTextField;
 
@@ -45,12 +44,9 @@ public class SubGuiAbilitySlam extends SubGuiAbilityConfig {
 
         y += 24;
 
-        // Row 3: Min/Max Leap Distance
-        addLabel(new GuiNpcLabel(104, "ability.minDist", labelX, y + 5));
-        addTextField(createFloatField(104, fieldX, y, 50, slam.getMinLeapDistance()));
-
-        addLabel(new GuiNpcLabel(105, "ability.maxDist", col2LabelX, y + 5));
-        addTextField(createFloatField(105, col2FieldX, y, 50, slam.getMaxLeapDistance()));
+        // Row 3: Leap Height
+        addLabel(new GuiNpcLabel(104, "ability.leapHeight", labelX, y + 5));
+        addTextField(createFloatField(104, fieldX, y, 50, slam.getLeapHeight()));
     }
 
     @Override
@@ -60,8 +56,7 @@ public class SubGuiAbilitySlam extends SubGuiAbilityConfig {
             case 101: slam.setRadius(parseFloat(field, slam.getRadius())); break;
             case 102: slam.setKnockbackStrength(parseFloat(field, slam.getKnockbackStrength())); break;
             case 103: slam.setLeapSpeed(parseFloat(field, slam.getLeapSpeed())); break;
-            case 104: slam.setMinLeapDistance(parseFloat(field, slam.getMinLeapDistance())); break;
-            case 105: slam.setMaxLeapDistance(parseFloat(field, slam.getMaxLeapDistance())); break;
+            case 104: slam.setLeapHeight(parseFloat(field, slam.getLeapHeight())); break;
         }
     }
 }

--- a/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityTeleport.java
+++ b/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityTeleport.java
@@ -27,55 +27,77 @@ public class SubGuiAbilityTeleport extends SubGuiAbilityConfig {
         int col2LabelX = guiLeft + 145;
         int col2FieldX = guiLeft + 205;
 
-        // Row 1: Pattern
-        addLabel(new GuiNpcLabel(100, "ability.pattern", labelX, y + 5));
-        String[] patterns = {"Random", "Toward", "Away", "Behind", "InFront", "Around", "ToTarget"};
-        addButton(new GuiNpcButton(100, fieldX, y, 80, 20, patterns, teleport.getPattern().ordinal()));
+        // Row 1: Mode
+        addLabel(new GuiNpcLabel(100, "ability.mode", labelX, y + 5));
+        String[] modes = {"Blink", "Behind", "Single"};
+        addButton(new GuiNpcButton(100, fieldX, y, 80, 20, modes, teleport.getMode().ordinal()));
 
         y += 24;
 
-        // Row 2: Blink Radius + Min Blink Radius
-        addLabel(new GuiNpcLabel(101, "ability.blinkRadius", labelX, y + 5));
-        addTextField(createFloatField(101, fieldX, y, 50, teleport.getBlinkRadius()));
+        switch (teleport.getMode()) {
+            case BLINK:
+                // Row 2: Blink Radius + Blink Count
+                addLabel(new GuiNpcLabel(101, "ability.blinkRadius", labelX, y + 5));
+                addTextField(createFloatField(101, fieldX, y, 50, teleport.getBlinkRadius()));
 
-        addLabel(new GuiNpcLabel(102, "ability.minBlinkRad", col2LabelX, y + 5));
-        addTextField(createFloatField(102, col2FieldX, y, 50, teleport.getMinBlinkRadius()));
+                addLabel(new GuiNpcLabel(102, "ability.blinkCount", col2LabelX, y + 5));
+                addTextField(createIntField(102, col2FieldX, y, 50, teleport.getBlinkCount()));
+
+                y += 24;
+
+                // Row 3: Blink Delay + Line of Sight
+                addLabel(new GuiNpcLabel(103, "ability.blinkDelay", labelX, y + 5));
+                addTextField(createIntField(103, fieldX, y, 50, teleport.getBlinkDelayTicks()));
+
+                addLabel(new GuiNpcLabel(105, "ability.lineOfSight", col2LabelX, y + 5));
+                addButton(new GuiNpcButton(105, col2FieldX, y, 50, 20, new String[]{"gui.no", "gui.yes"}, teleport.isRequireLineOfSight() ? 1 : 0));
+                y += 24;
+                break;
+            case SINGLE:
+                // Row 2: Blink Radius + Line of Sight
+                addLabel(new GuiNpcLabel(101, "ability.blinkRadius", labelX, y + 5));
+                addTextField(createFloatField(101, fieldX, y, 50, teleport.getBlinkRadius()));
+
+                addLabel(new GuiNpcLabel(105, "ability.lineOfSight", col2LabelX, y + 5));
+                addButton(new GuiNpcButton(105, col2FieldX, y, 50, 20, new String[]{"gui.no", "gui.yes"}, teleport.isRequireLineOfSight() ? 1 : 0));
+                y += 24;
+                break;
+            case BEHIND:
+                // Row 2: Behind Distance
+                addLabel(new GuiNpcLabel(104, "ability.behindDistance", labelX, y + 5));
+                addTextField(createFloatField(104, fieldX, y, 50, teleport.getBehindDistance()));
+                y += 24;
+                break;
+        }
+
+        // Damage + Damage Radius
+        addLabel(new GuiNpcLabel(106, "ability.damage", labelX, y + 5));
+        addTextField(createFloatField(106, fieldX, y, 50, teleport.getDamage()));
+
+        addLabel(new GuiNpcLabel(107, "ability.dmgRadius", col2LabelX, y + 5));
+        addTextField(createFloatField(107, col2FieldX, y, 50, teleport.getDamageRadius()));
 
         y += 24;
 
-        // Row 3: Blink Count + Blink Delay
-        addLabel(new GuiNpcLabel(103, "ability.blinkCount", labelX, y + 5));
-        addTextField(createIntField(103, fieldX, y, 50, teleport.getBlinkCount()));
+        // Damage at Start/End
+        addLabel(new GuiNpcLabel(108, "ability.dmgAtStart", labelX, y + 5));
+        addButton(new GuiNpcButton(108, fieldX, y, 50, 20, new String[]{"gui.no", "gui.yes"}, teleport.isDamageAtStart() ? 1 : 0));
 
-        addLabel(new GuiNpcLabel(104, "ability.blinkDelay", col2LabelX, y + 5));
-        addTextField(createIntField(104, col2FieldX, y, 50, teleport.getBlinkDelayTicks()));
-
-        y += 24;
-
-        // Row 4: Damage + Damage Radius
-        addLabel(new GuiNpcLabel(105, "ability.damage", labelX, y + 5));
-        addTextField(createFloatField(105, fieldX, y, 50, teleport.getDamage()));
-
-        addLabel(new GuiNpcLabel(106, "ability.dmgRadius", col2LabelX, y + 5));
-        addTextField(createFloatField(106, col2FieldX, y, 50, teleport.getDamageRadius()));
-
-        y += 24;
-
-        // Row 5: Damage at Start/End + Require LOS
-        addLabel(new GuiNpcLabel(107, "ability.dmgAtStart", labelX, y + 5));
-        addButton(new GuiNpcButton(107, fieldX, y, 50, 20, new String[]{"gui.no", "gui.yes"}, teleport.isDamageAtStart() ? 1 : 0));
-
-        addLabel(new GuiNpcLabel(108, "ability.dmgAtEnd", col2LabelX, y + 5));
-        addButton(new GuiNpcButton(108, col2FieldX, y, 50, 20, new String[]{"gui.no", "gui.yes"}, teleport.isDamageAtEnd() ? 1 : 0));
+        addLabel(new GuiNpcLabel(109, "ability.dmgAtEnd", col2LabelX, y + 5));
+        addButton(new GuiNpcButton(109, col2FieldX, y, 50, 20, new String[]{"gui.no", "gui.yes"}, teleport.isDamageAtEnd() ? 1 : 0));
     }
 
     @Override
     protected void handleTypeButton(int id, GuiNpcButton button) {
         int value = button.getValue();
         switch (id) {
-            case 100: teleport.setPattern(AbilityTeleport.TeleportPattern.values()[value]); break;
-            case 107: teleport.setDamageAtStart(value == 1); break;
-            case 108: teleport.setDamageAtEnd(value == 1); break;
+            case 100:
+                teleport.setMode(AbilityTeleport.TeleportMode.values()[value]);
+                initGui();
+                break;
+            case 105: teleport.setRequireLineOfSight(value == 1); break;
+            case 108: teleport.setDamageAtStart(value == 1); break;
+            case 109: teleport.setDamageAtEnd(value == 1); break;
         }
     }
 
@@ -83,11 +105,11 @@ public class SubGuiAbilityTeleport extends SubGuiAbilityConfig {
     protected void handleTypeTextField(int id, GuiNpcTextField field) {
         switch (id) {
             case 101: teleport.setBlinkRadius(parseFloat(field, teleport.getBlinkRadius())); break;
-            case 102: teleport.setMinBlinkRadius(parseFloat(field, teleport.getMinBlinkRadius())); break;
-            case 103: teleport.setBlinkCount(field.getInteger()); break;
-            case 104: teleport.setBlinkDelayTicks(field.getInteger()); break;
-            case 105: teleport.setDamage(parseFloat(field, teleport.getDamage())); break;
-            case 106: teleport.setDamageRadius(parseFloat(field, teleport.getDamageRadius())); break;
+            case 102: teleport.setBlinkCount(field.getInteger()); break;
+            case 103: teleport.setBlinkDelayTicks(field.getInteger()); break;
+            case 104: teleport.setBehindDistance(parseFloat(field, teleport.getBehindDistance())); break;
+            case 106: teleport.setDamage(parseFloat(field, teleport.getDamage())); break;
+            case 107: teleport.setDamageRadius(parseFloat(field, teleport.getDamageRadius())); break;
         }
     }
 }

--- a/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityTrap.java
+++ b/src/main/java/noppes/npcs/client/gui/advanced/ability/SubGuiAbilityTrap.java
@@ -64,12 +64,9 @@ public class SubGuiAbilityTrap extends SubGuiAbilityConfig {
 
         y += 24;
 
-        // Row 5: Knockback + Knockback Up
+        // Row 5: Knockback
         addLabel(new GuiNpcLabel(108, "ability.knockback", labelX, y + 5));
         addTextField(createFloatField(108, fieldX, y, 50, trap.getKnockback()));
-
-        addLabel(new GuiNpcLabel(109, "ability.knockbackUp", col2LabelX, y + 5));
-        addTextField(createFloatField(109, col2FieldX, y, 50, trap.getKnockbackUp()));
     }
 
     @Override
@@ -90,7 +87,6 @@ public class SubGuiAbilityTrap extends SubGuiAbilityConfig {
             case 106: trap.setRootDuration(field.getInteger()); break;
             case 107: trap.setStunDuration(field.getInteger()); break;
             case 108: trap.setKnockback(parseFloat(field, trap.getKnockback())); break;
-            case 109: trap.setKnockbackUp(parseFloat(field, trap.getKnockbackUp())); break;
         }
     }
 }

--- a/src/main/resources/assets/customnpcs/lang/en_US.lang
+++ b/src/main/resources/assets/customnpcs/lang/en_US.lang
@@ -1519,6 +1519,15 @@ ability.lifetime=Lifetime
 ability.stunTicks=Stun
 ability.stunDur=Stun Dur
 ability.rootDur=Root Dur
+ability.rootDuration=Root Duration
+ability.stunDuration=Stun Duration
+ability.leapHeight=Leap Height
+ability.hitWidth=Hit Width
+ability.potionTime=Potion Time (s)
+ability.weaknessLvl=Weakness Lvl
+ability.poisonTime=Poison Time (s)
+ability.slownessLvl=Slowness Lvl
+ability.poisonLvl=Poison Lvl
 
 # Slam Settings
 ability.leapSpeed=Leap Speed
@@ -1550,6 +1559,8 @@ ability.maxTargets=Max Targets
 ability.dashMode=Mode
 ability.dash.aggressive=Aggressive
 ability.dash.defensive=Defensive
+ability.mode=Mode
+ability.behindDistance=Behind Dist
 
 # Teleport Settings
 ability.blinkCount=Blinks
@@ -1576,6 +1587,10 @@ ability.dmgReduce=Dmg Reduce
 ability.counterDmg=Counter Dmg
 ability.canCounter=Counter
 ability.counterChance=Counter %
+ability.counterType=Counter Type
+ability.counterValue=Counter Value
+ability.counterSound=Counter Sound
+ability.counterAnim=Counter Anim
 
 # Heal Settings
 ability.healAmount=Amount
@@ -1631,6 +1646,7 @@ ability.activeColor=Active Color
 # Shockwave Settings
 ability.pushRadius=Push Radius
 ability.pushStrength=Push Str
+ability.shockwaveFalloff=Damage/knockback drop off with distance
 
 # Ability Config GUI
 ability.typeId=Type ID


### PR DESCRIPTION
### Motivation

- Remove legacy vertical knockback (`KB Up`) and make ability knockback behave like NPC hits so forces are applied consistently.
- Simplify and de-bloat ability configs while providing sane defaults and Minecraft 1.7.10-style sounds for ability feedback.
- Improve movement and safety for movement-based abilities by adding collision checks and safer teleport destination selection.
- Provide clearer, more flexible ability options (teleport modes, cutter sweep modes, guard counter types, vortex pull behavior and damage pacing).

### Description

- Reworked ability damage API: added an overload of `applyAbilityDamage` without vertical knockback, centralized horizontal knockback into `applyNpcKnockback`, and updated `applyAbilityDamageWithDirection` to ignore vertical KB; updated all callers accordingly (`Ability.java`, `DataAbilities.fireHitEvent` comment updated). 
- Reworked ability types to remove vertical-KB fields and add simplified parameters and defaults (examples: `AbilityHeavyHit` uses slowness/weakness + `potionDurationSeconds`; `AbilitySlam` uses `leapHeight`; `AbilityCharge` uses `hitWidth` and stops on collision; `AbilityCutter` adds `SWIPE`/`SPIN` and `sweepSpeed` + poison; `AbilityVortex` pulls to NPC and applies periodic pull damage; `AbilityShockwave` removes AOE flag and vertical push); also added sensible default sounds for many abilities. 
- Teleport overhaul: replaced legacy patterns with `TeleportMode` (`BLINK`, `BEHIND`, `SINGLE`), conditional GUI fields per mode, LOS and safe-destination checks, multiple blinks and delays, and compatibility for legacy NBT patterns. 
- Guard overhaul and integration: introduced `CounterType` (`FLAT`/`PERCENT`), `counterValue`, `counterSound`, `counterAnimationId`, `onDamageTaken` handling, and hooked guard damage handling into `CombatHandler` so counters occur on direct hits; added GUI and language entries for the new options. 
- Misc GUI and language updates: updated type-specific GUIs (`SubGuiAbility*`) to reflect renamed/removed fields and to expose new parameters; added/updated language keys in `en_US.lang`.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963242c8a4083238c236ed474b22368)