### PR TITLE
feat: preserve items in custom NPC CarpentryBench after GUI closes

### DIFF
--- a/src/main/java/noppes/npcs/blocks/tiles/TileBlockAnvil.java
+++ b/src/main/java/noppes/npcs/blocks/tiles/TileBlockAnvil.java
@@ -1,11 +1,15 @@
 package noppes.npcs.blocks.tiles;
 
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.EnumSkyBlock;
 
 public class TileBlockAnvil extends TileEntity {
 
     public boolean firstTick = true;
+    public ItemStack[] items = new ItemStack[16];
 
     public TileBlockAnvil() {
     }
@@ -20,6 +24,43 @@ public class TileBlockAnvil extends TileEntity {
             firstTick = false;
             getWorldObj().updateLightByType(EnumSkyBlock.Block, xCoord, yCoord, zCoord);
             getWorldObj().markBlockForUpdate(xCoord, yCoord, zCoord);
+        }
+    }
+
+    @Override
+    public void writeToNBT(NBTTagCompound compound) {
+        super.writeToNBT(compound);
+
+        NBTTagList list = new NBTTagList();
+
+        for (int i = 0; i < items.length; i++) {
+            if (items[i] != null) {
+                NBTTagCompound tag = new NBTTagCompound();
+                tag.setByte("Slot", (byte) i);
+                items[i].writeToNBT(tag);
+                list.appendTag(tag);
+            }
+        }
+
+        compound.setTag("Items", list);
+
+
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound compound) {
+        super.readFromNBT(compound);
+
+        NBTTagList list = compound.getTagList("Items", 10); // 10 = NBTTagCompound
+        this.items = new ItemStack[16];
+
+        for (int i = 0; i < list.tagCount(); i++) {
+            NBTTagCompound tag = list.getCompoundTagAt(i);
+            int slot = tag.getByte("Slot") & 255;
+
+            if (slot >= 0 && slot < items.length) {
+                items[slot] = ItemStack.loadItemStackFromNBT(tag);
+            }
         }
     }
 }

--- a/src/main/java/noppes/npcs/containers/ContainerCarpentryBench.java
+++ b/src/main/java/noppes/npcs/containers/ContainerCarpentryBench.java
@@ -12,9 +12,11 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.inventory.SlotCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.server.S2FPacketSetSlot;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import noppes.npcs.CustomItems;
 import noppes.npcs.EventHooks;
+import noppes.npcs.blocks.tiles.TileBlockAnvil;
 import noppes.npcs.controllers.RecipeController;
 import noppes.npcs.controllers.data.RecipeCarpentry;
 import noppes.npcs.scripted.event.RecipeScriptEvent;
@@ -58,12 +60,21 @@ public class ContainerCarpentryBench extends Container {
         for (var6 = 0; var6 < 9; ++var6) {
             this.addSlotToContainer(new Slot(par1InventoryPlayer, var6, 8 + var6 * 18, 156));
         }
-
+        restoreCraftMatrix();
         this.onCraftMatrixChanged(this.craftMatrix);
     }
 
     public int getMetadata() {
         return worldObj.getBlockMetadata(posX, posY, posZ);
+    }
+
+    private void restoreCraftMatrix() {
+        TileEntity tileEntity = worldObj.getTileEntity(posX, posY, posZ);
+        if (tileEntity instanceof TileBlockAnvil) {
+            for (int i = 0; i < ((TileBlockAnvil) tileEntity).items.length; i++) {
+                craftMatrix.setInventorySlotContents(i, ((TileBlockAnvil) tileEntity).items[i]);
+            }
+        }
     }
 
     /**
@@ -108,13 +119,14 @@ public class ContainerCarpentryBench extends Container {
         super.onContainerClosed(par1EntityPlayer);
 
         if (!this.worldObj.isRemote) {
+            TileEntity tileEntity = worldObj.getTileEntity(posX, posY, posZ);
             for (int var2 = 0; var2 < 16; ++var2) {
                 ItemStack var3 = this.craftMatrix.getStackInSlotOnClosing(var2);
-
-                if (var3 != null) {
-                    par1EntityPlayer.dropPlayerItemWithRandomChoice(var3, false);
+                if (tileEntity instanceof TileBlockAnvil) {
+                    ((TileBlockAnvil) tileEntity).items[var2] = var3;
                 }
             }
+            tileEntity.markDirty();
         }
     }
 


### PR DESCRIPTION
Added support for retaining the CarpentryBench inventory when the GUI is closed. The bench now keeps its internal items and restores them on the next open.