### PR TITLE
Fix NpcVisible for legacy npc

### DIFF
--- a/src/main/java/noppes/npcs/VersionCompatibility.java
+++ b/src/main/java/noppes/npcs/VersionCompatibility.java
@@ -110,6 +110,10 @@ public class VersionCompatibility {
 
                 compound.setIntArray("StartPosNew", new int[]{x, y, z});
             }
+
+            if (!compound.getString("GlowTexture").isEmpty() && compound.getInteger("NpcVisible") == 1) {
+                compound.setInteger("NpcVisible", 2);
+            }
         }
         if (npc.npcVersion == 13) {
             boolean bo = compound.getBoolean("HealthRegen");


### PR DESCRIPTION
In older versions of CNPC, when a GlowTexture was set, and NpcVisible == 1, its display was fixed at NpcVisible == 2.