### PR TITLE
refactor: disable auto-open GUI for BlockBorder and BlockNpcRedstone

### DIFF
--- a/src/main/java/noppes/npcs/blocks/BlockBorder.java
+++ b/src/main/java/noppes/npcs/blocks/BlockBorder.java
@@ -67,10 +67,6 @@ public class BlockBorder extends BlockContainer {
         }
 
         tile.rotation = l;
-
-        if (par5EntityLivingBase instanceof EntityPlayer && par1World.isRemote) {
-            CustomNpcs.proxy.openGui(x, y, z, EnumGuiType.Border, (EntityPlayer) par5EntityLivingBase);
-        }
     }
 
     private TileBorder getTile(World world, int x, int y, int z) {

--- a/src/main/java/noppes/npcs/blocks/BlockNpcRedstone.java
+++ b/src/main/java/noppes/npcs/blocks/BlockNpcRedstone.java
@@ -50,13 +50,6 @@ public class BlockNpcRedstone extends BlockContainer {
     }
 
     @Override
-    public void onBlockPlacedBy(World world, int i, int j, int k, EntityLivingBase entityliving, ItemStack item) {
-        if (entityliving instanceof EntityPlayer && world.isRemote) {
-            CustomNpcs.proxy.openGui(i, j, k, EnumGuiType.RedstoneBlock, (EntityPlayer) entityliving);
-        }
-    }
-
-    @Override
     public void onBlockDestroyedByPlayer(World par1World, int par2, int par3, int par4, int par5) {
         onBlockAdded(par1World, par2, par3, par4);
     }

--- a/src/main/java/noppes/npcs/client/gui/SubGuiNpcAvailabilityDialog.java
+++ b/src/main/java/noppes/npcs/client/gui/SubGuiNpcAvailabilityDialog.java
@@ -112,19 +112,19 @@ public class SubGuiNpcAvailabilityDialog extends SubGuiInterface implements GuiS
         }
         if (button.id == 10) {
             slot = 1;
-            setSubGui(new GuiDialogSelection(availabitily.questId));
+            setSubGui(new GuiDialogSelection(availabitily.dialogId));
         }
         if (button.id == 11) {
             slot = 2;
-            setSubGui(new GuiDialogSelection(availabitily.quest2Id));
+            setSubGui(new GuiDialogSelection(availabitily.dialog2Id));
         }
         if (button.id == 12) {
             slot = 3;
-            setSubGui(new GuiDialogSelection(availabitily.quest3Id));
+            setSubGui(new GuiDialogSelection(availabitily.dialog3Id));
         }
         if (button.id == 13) {
             slot = 4;
-            setSubGui(new GuiDialogSelection(availabitily.quest4Id));
+            setSubGui(new GuiDialogSelection(availabitily.dialog4Id));
         }
         if (button.id == 20) {
             availabitily.dialogId = -1;


### PR DESCRIPTION
- Removed auto-open GUI logic upon placing BlockBorder and BlockNpcRedstone.
- Resolved a race condition where the GUI would open before NBT/Permission data was fully synced from the server, causing "Permission Denied" or empty states.
- Fixed a logic bug in SubGuiNpcAvailabilityDialog where 'questId' was incorrectly used instead of 'dialogId' when opening the selection picker.
- This change ensures better UX as manual interaction guarantees all data is properly initialized.