### PR TITLE
fix: adapt quest tracker height to content

### DIFF
--- a/src/main/java/noppes/npcs/client/gui/hud/QuestTrackingComponent.java
+++ b/src/main/java/noppes/npcs/client/gui/hud/QuestTrackingComponent.java
@@ -39,6 +39,7 @@ public class QuestTrackingComponent extends HudComponent {
         if (turnIn != null && !turnIn.isEmpty()) {
             turnInLines.add(convertColorCodes(turnIn));
         }
+        updateOverlayHeight();
     }
 
     /**
@@ -239,6 +240,19 @@ public class QuestTrackingComponent extends HudComponent {
     }
 
     // ---------- Helper rendering methods ----------- (methods unchanged) ...
+    private void updateOverlayHeight() {
+        int lineHeight = mc.fontRenderer.FONT_HEIGHT + 4;
+        int contentHeight = 5;
+        contentHeight += questTitleLines.size() * lineHeight + 8;
+        contentHeight += questCategoryLines.size() * lineHeight + 8;
+        contentHeight += objectiveLines.size() * lineHeight;
+        if (!turnInLines.isEmpty()) {
+            contentHeight += 8;
+        }
+        contentHeight += turnInLines.size() * lineHeight;
+        overlayHeight = contentHeight;
+    }
+
     private int renderTextBlock(List<String> lines, int startY, int align, int color) {
         int y = startY;
         FontRenderer font = mc.fontRenderer;


### PR DESCRIPTION
## Summary
Fixes the quest tracker background panel leaving unnecessary empty shadow space below its content.
The tracker height is now calculated dynamically from the content currently being displayed, including:
- Quest title lines
- Quest category lines
- Objective lines
- Turn-in information
- Text spacing and section separators
This keeps the semi-transparent background aligned with the actual content instead of always using the fixed default height.
## Before
The quest tracker used a fixed height, leaving a large empty shadow area below shorter quest content.

<img width="662" height="479" alt="PixPin_2026-08-02_22-10-31" src="https://github.com/user-attachments/assets/f26af197-471a-4158-b98c-1d28f754093d" />

## After
The background panel now adapts to the rendered content height.

<img width="1920" height="1009" alt="47546bad7c6aa8fddced9e6dcae3a779" src="https://github.com/user-attachments/assets/1a44336d-6e99-43b4-8b29-b0f53a72cd81" />

## Implementation
Added an `updateOverlayHeight()` calculation to `QuestTrackingComponent`. The calculated height follows the same line-height and spacing rules used by the rendering flow.
## Testing
- [x] Verified `IAbilityEvent.DefendEvent` is available from the `dev` API submodule revision
- [x] Ran `./gradlew compileJava`
- [x] Build completed successfully
- [x] Verified the quest tracker background adapts to its displayed content
- [x] Verified the excess shadow area is no longer displayed
## Build Result
```text
BUILD SUCCESSFUL
 ```