### PR TITLE
Fix inverted directLOS logic causing NPCs to see through solid blocks

### DIFF
--- a/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
+++ b/src/main/java/noppes/npcs/entity/EntityNPCInterface.java
@@ -815,7 +815,7 @@ public abstract class EntityNPCInterface extends EntityCreature implements IEnti
                     if (npc.isKilled() || !npc.advanced.defendFaction || npc.faction.id != faction.id)
                         continue;
 
-                    if (npc.canSee(this) || npc.ais.directLOS || npc.canSee(attackingEntity))
+                    if (!npc.ais.directLOS || npc.canSee(this) || npc.canSee(attackingEntity))
                         npc.onAttack(attackingEntity);
                 }
                 setAttackTarget(attackingEntity);


### PR DESCRIPTION
### Fix inverted `directLOS` logic causing NPCs to see through solid blocks

####
Fixes a boolean logic short-circuit in the faction defense AI check where enabling `directLOS` (Direct Line of Sight) accidentally allowed NPCs to bypass physical raytracing checks and see target entities through solid blocks.