### PR TITLE
fix(dialog): anchor option indicators to dialog text

### DIFF
--- a/src/main/java/noppes/npcs/client/gui/player/GuiDialogInteract.java
+++ b/src/main/java/noppes/npcs/client/gui/player/GuiDialogInteract.java
@@ -38,6 +38,9 @@ import java.util.HashMap;
 import java.util.List;
 
 public class GuiDialogInteract extends GuiNPCInterface implements IGuiClose {
+    private static final String OPTION_INDICATOR = ">";
+    private static final int OPTION_INDICATOR_GAP = 2;
+
     private GuiScreen parent;
     private Dialog dialog;
     private int selected = 0;
@@ -478,10 +481,12 @@ public class GuiDialogInteract extends GuiNPCInterface implements IGuiClose {
             int id = options.get(k);
             DialogOption option = dialog.options.get(id);
             int y = offset + (k + 1) * ClientProxy.Font.height();
+            int optionTextX = getOptionTextX(k);
+            String optionText = NoppesStringUtils.formatText(option.title, player, npc);
             offset += dialog.optionSpaceY;
 
             if (selected == k) {
-                drawString(fontRendererObj, ">", guiLeft - 60, y, 0xe0e0e0);
+                drawString(fontRendererObj, OPTION_INDICATOR, getOptionIndicatorX(optionTextX, optionText), y, 0xe0e0e0);
             }
 
             GL11.glPushMatrix();
@@ -501,7 +506,7 @@ public class GuiDialogInteract extends GuiNPCInterface implements IGuiClose {
                 OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
                 GL11.glDisable(GL11.GL_ALPHA_TEST);
 
-                GL11.glTranslatef(guiLeft - 30 + dialog.optionSpaceX * k, y, 0.0F);
+                GL11.glTranslatef(optionTextX, y, 0.0F);
                 image.color = selected == k ? image.selectedColor : image.color;
                 GL11.glTranslatef(image.x, image.y, 0.0f);
                 image.onRender(mc);
@@ -512,9 +517,32 @@ public class GuiDialogInteract extends GuiNPCInterface implements IGuiClose {
             }
             GL11.glPopMatrix();
 
-            drawString(fontRendererObj, NoppesStringUtils.formatText(option.title, player, npc), guiLeft - 30 + dialog.optionSpaceX * k, y, option.optionColor);
+            drawString(fontRendererObj, optionText, optionTextX, y, option.optionColor);
             GL11.glPopMatrix();
         }
+    }
+
+    private int getOptionTextX(int optionIndex) {
+        return guiLeft - 30 + dialog.optionSpaceX * optionIndex;
+    }
+
+    private int getOptionIndicatorX(int optionTextX, String optionText) {
+        return optionTextX + getLeadingTextWidth(optionText) - ClientProxy.Font.width(OPTION_INDICATOR) - OPTION_INDICATOR_GAP;
+    }
+
+    private int getLeadingTextWidth(String text) {
+        int prefixEnd = 0;
+        while (prefixEnd < text.length()) {
+            char character = text.charAt(prefixEnd);
+            if (character == '\u00A7' && prefixEnd + 1 < text.length()) {
+                prefixEnd += 2;
+            } else if (Character.isWhitespace(character)) {
+                prefixEnd++;
+            } else {
+                break;
+            }
+        }
+        return ClientProxy.Font.width(text.substring(0, prefixEnd));
     }
 
     private void drawDialogString(String text, int left, int count, boolean mainDialogText, TextBlockClient block) {
@@ -741,4 +769,3 @@ public class GuiDialogInteract extends GuiNPCInterface implements IGuiClose {
         grabMouse(false);
     }
 }
-

--- a/src/main/java/noppes/npcs/client/gui/player/modern/GuiModernDialogInteract.java
+++ b/src/main/java/noppes/npcs/client/gui/player/modern/GuiModernDialogInteract.java
@@ -37,6 +37,8 @@ import java.util.Iterator;
 import java.util.List;
 
 public class GuiModernDialogInteract extends GuiNPCInterface implements IGuiClose {
+    private static final int OPTION_INDICATOR_GAP = 2;
+
     private Dialog dialog;
     private int selected = 0;
     private List<TextBlockClient> lineBlocks = new ArrayList<TextBlockClient>();
@@ -192,6 +194,7 @@ public class GuiModernDialogInteract extends GuiNPCInterface implements IGuiClos
         selected = -1;
         for (int i = 0; i < this.options.size(); i++) {
             int optionHeight = height / 2 - 30 + i * (13 + 6);
+            int optionTextX = width - 221;
             int optionNum = options.get(i);
             DialogOption option = dialog.options.get(optionNum);
             if (mouseX >= width - 237 && mouseX <= width - 14 && mouseY >= optionHeight && mouseY <= optionHeight + 13) {
@@ -204,9 +207,9 @@ public class GuiModernDialogInteract extends GuiNPCInterface implements IGuiClos
             if (getQuestByOptionId(optionNum) != null) {
                 drawString(fontRendererObj, "!", width - 229, optionHeight + 3, 0x76e85b);
             } else {
-                drawString(fontRendererObj, ">", width - 229, optionHeight + 3, -1);
+                drawString(fontRendererObj, ">", getOptionIndicatorX(optionTextX), optionHeight + 3, -1);
             }
-            drawString(fontRendererObj, option.title, width - 221, optionHeight + 3, option.optionColor);
+            drawString(fontRendererObj, option.title, optionTextX, optionHeight + 3, option.optionColor);
         }
         GL11.glPopMatrix();
         GL11.glPopMatrix();
@@ -218,6 +221,10 @@ public class GuiModernDialogInteract extends GuiNPCInterface implements IGuiClos
             return option.getDialog().getQuest();
         }
         return null;
+    }
+
+    private int getOptionIndicatorX(int optionTextX) {
+        return optionTextX - ClientProxy.Font.width(">") - OPTION_INDICATOR_GAP;
     }
 
     public void drawNpc(EntityNPCInterface entity, int x, int y, float zoomed, int rotation) {


### PR DESCRIPTION
## Summary
Fixes dialog option indicators being rendered too far to the left and hidden behind NPC models.

## Changes
- Anchor the classic dialog `>` indicator to the visible start of the selected option text.
- Account for leading whitespace and formatting codes when calculating the indicator position.
- Keep option text, option images, and interaction hitboxes unchanged.
- Apply the same text-relative positioning to the modern dialog GUI.
- Preserve existing quest `!` markers and radial dialog indicators.
<img width="873" height="511" alt="PixPin_2026-08-19_20-45-50" src="https://github.com/user-attachments/assets/22f46ca6-a7f0-4124-a5ab-b5f77a531df2" />
<img width="932" height="486" alt="PixPin_2026-08-19_20-43-28" src="https://github.com/user-attachments/assets/17e67428-36d7-4729-a950-e35db68a5861" />

## Now
<img width="3420" height="2146" alt="d6e26e1aac325c44295db099795f6dc0" src="https://github.com/user-attachments/assets/5633dfbf-df9b-4033-9c35-e93bfce15728" />


## Testing
- `./gradlew compileJava --no-daemon`
- Manually verified the classic dialog GUI with an NPC model and multiple options.