### PR TITLE
Add Back auto-open GUI for BlockBorder and BlockNpcRedstone

### DIFF
--- a/src/main/java/noppes/npcs/blocks/BlockBorder.java
+++ b/src/main/java/noppes/npcs/blocks/BlockBorder.java
@@ -67,6 +67,10 @@ public class BlockBorder extends BlockContainer {
         }
 
         tile.rotation = l;
+
+        if (par5EntityLivingBase instanceof EntityPlayer) {
+            CustomNpcs.proxy.openGui(x, y, z, EnumGuiType.Border, (EntityPlayer) par5EntityLivingBase);
+        }
     }
 
     private TileBorder getTile(World world, int x, int y, int z) {

--- a/src/main/java/noppes/npcs/blocks/BlockNpcRedstone.java
+++ b/src/main/java/noppes/npcs/blocks/BlockNpcRedstone.java
@@ -50,6 +50,13 @@ public class BlockNpcRedstone extends BlockContainer {
     }
 
     @Override
+    public void onBlockPlacedBy(World world, int i, int j, int k, EntityLivingBase entityliving, ItemStack item) {
+        if (entityliving instanceof EntityPlayer && !world.isRemote) {
+            CustomNpcs.proxy.openGui(i, j, k, EnumGuiType.RedstoneBlock, (EntityPlayer) entityliving);
+        }
+    }
+
+    @Override
     public void onBlockDestroyedByPlayer(World par1World, int par2, int par3, int par4, int par5) {
         onBlockAdded(par1World, par2, par3, par4);
     }


### PR DESCRIPTION
It was previously removed due to a bug; testing has confirmed that the patch fixes this issue, so the feature has been added back.