### PR TITLE
Disable auto open gui 2

### DIFF
--- a/src/main/java/noppes/npcs/blocks/BlockWaypoint.java
+++ b/src/main/java/noppes/npcs/blocks/BlockWaypoint.java
@@ -38,19 +38,6 @@ public class BlockWaypoint extends BlockContainer {
     }
 
     @Override
-    public void onBlockPlacedBy(World world, int i, int j, int k, EntityLivingBase entityliving, ItemStack item) {
-        if (entityliving instanceof EntityPlayer) {
-            if (!world.isRemote) {
-                // Server-side: sync TileEntity data to client and open GUI (same as onBlockActivated)
-                TileEntity tile = world.getTileEntity(i, j, k);
-                NBTTagCompound compound = new NBTTagCompound();
-                tile.writeToNBT(compound);
-                PacketHandler.Instance.sendToPlayer(new GuiWaypointPacket(compound), (EntityPlayerMP) entityliving);
-            }
-        }
-    }
-
-    @Override
     public TileEntity createNewTileEntity(World var1, int var2) {
         return new TileWaypoint();
     }


### PR DESCRIPTION
continue #283 

When placing these blocks, the player's configuration settings cannot be saved. because the `TileEntity` is saved via a network packet. This packet validates the item held by the player—such as an NPC Wand—before saving; however, the player inevitably fails to meet the required criteria at the moment of placement.