### PR TITLE
fix(nbt-json): stop stripping leading spaces in NBT string parsing

### DIFF
--- a/src/main/java/noppes/npcs/util/NBTJsonUtil.java
+++ b/src/main/java/noppes/npcs/util/NBTJsonUtil.java
@@ -114,7 +114,7 @@ public class NBTJsonUtil {
             return list;
         }
         if (json.startsWith("\"")) {
-            json.cut(1);
+            json.cutDirty(1);
             String s = "";
             boolean ignore = false;
             while (!json.startsWith("\"") || ignore) {


### PR DESCRIPTION
There is a bug in the NBT-to-JSON serializer that causes inconsistencies with in-game item NBT data, affecting quest submission to some extent.