### PR TITLE
Improve Unicode/CJK automatic wrapping in TextBlockClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,12 @@ src/main/resources/assets/customnpcs/api
 df/
 tmp/
 src/test
+!src/test/
+!src/test/java/
+!src/test/java/noppes/
+!src/test/java/noppes/npcs/
+!src/test/java/noppes/npcs/client/
+!src/test/java/noppes/npcs/client/UnicodeLineWrapperTest.java
 node_modules
 .github/pages-dist
 

--- a/src/main/java/noppes/npcs/client/TextBlockClient.java
+++ b/src/main/java/noppes/npcs/client/TextBlockClient.java
@@ -9,6 +9,8 @@ import noppes.npcs.NoppesStringUtils;
 import noppes.npcs.TextBlock;
 import noppes.npcs.controllers.data.Dialog;
 
+import java.util.List;
+
 public class TextBlockClient extends TextBlock {
     private ChatStyle style;
     public int color = 0xe0e0e0;
@@ -41,38 +43,25 @@ public class TextBlockClient extends TextBlock {
         style = new ChatStyle();
         text = NoppesStringUtils.formatText(text, obs);
 
-        String line = "";
-        text = text.replace("\n", " \n ");
-        text = text.replace("\r", " \r ");
-        String[] words = text.split(" ");
-
-        FontRenderer font = Minecraft.getMinecraft().fontRenderer;
-        for (String word : words) {
-            if (word.isEmpty())
-                continue;
-            if (word.length() == 1) {
-                char c = word.charAt(0);
-                if (c == '\r' || c == '\n') {
-                    addLine(line);
-                    line = "";
-                    continue;
+        final FontRenderer font = Minecraft.getMinecraft().fontRenderer;
+        UnicodeLineWrapper.WidthMeasurer measurer = mcFont
+            ? new UnicodeLineWrapper.WidthMeasurer() {
+                @Override
+                public int width(String value) {
+                    return font.getStringWidth(value);
                 }
             }
-            String newLine;
-            if (line.isEmpty())
-                newLine = word;
-            else
-                newLine = line + " " + word;
+            : new UnicodeLineWrapper.WidthMeasurer() {
+                @Override
+                public int width(String value) {
+                    return ClientProxy.Font.width(value);
+                }
+            };
 
-            if ((mcFont ? font.getStringWidth(newLine) : ClientProxy.Font.width(newLine)) > lineWidth) {
-                addLine(line);
-                line = word.trim();
-            } else {
-                line = newLine;
-            }
-        }
-        if (!line.isEmpty())
+        List<String> wrappedLines = UnicodeLineWrapper.wrap(text, lineWidth, measurer);
+        for (String line : wrappedLines) {
             addLine(line);
+        }
     }
 
     private void addLine(String text) {

--- a/src/main/java/noppes/npcs/client/UnicodeLineWrapper.java
+++ b/src/main/java/noppes/npcs/client/UnicodeLineWrapper.java
@@ -1,0 +1,389 @@
+package noppes.npcs.client;
+
+import java.text.BreakIterator;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Wraps formatted Unicode text using the JRE's locale-neutral line breaking
+ * rules. Minecraft formatting codes are retained in the result, but omitted
+ * from the text passed to the line and grapheme break iterators.
+ */
+final class UnicodeLineWrapper {
+    private static final char FORMAT_MARKER = '\u00a7';
+
+    interface WidthMeasurer {
+        int width(String text);
+    }
+
+    private UnicodeLineWrapper() {
+    }
+
+    static List<String> wrap(String text, int maxWidth, WidthMeasurer measurer) {
+        if (text == null || text.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (measurer == null) {
+            throw new IllegalArgumentException("measurer must not be null");
+        }
+
+        List<String> lines = new ArrayList<String>();
+        int paragraphStart = 0;
+        for (int i = 0; i < text.length(); i++) {
+            char current = text.charAt(i);
+            if (current != '\r' && current != '\n') {
+                continue;
+            }
+
+            addParagraph(lines, text.substring(paragraphStart, i), maxWidth, measurer, true);
+            if (current == '\r' && i + 1 < text.length() && text.charAt(i + 1) == '\n') {
+                i++;
+            }
+            paragraphStart = i + 1;
+        }
+
+        // A final hard break terminates the current line; it does not create an
+        // additional empty line after it.
+        if (paragraphStart < text.length()) {
+            addParagraph(lines, text.substring(paragraphStart), maxWidth, measurer, false);
+        }
+        return lines;
+    }
+
+    private static void addParagraph(List<String> lines, String paragraph, int maxWidth,
+                                     WidthMeasurer measurer, boolean endedByHardBreak) {
+        Paragraph parsed = Paragraph.parse(normalizeSpaces(paragraph));
+        if (parsed.visible.isEmpty()) {
+            if (endedByHardBreak) {
+                lines.add("");
+            }
+            return;
+        }
+
+        BreakIterator lineIterator = BreakIterator.getLineInstance(Locale.ROOT);
+        lineIterator.setText(parsed.visible);
+        BreakIterator characterIterator = BreakIterator.getCharacterInstance(Locale.ROOT);
+        characterIterator.setText(parsed.visible);
+
+        int start = 0;
+        while (start < parsed.visible.length()) {
+            int end;
+            if (maxWidth <= 0) {
+                end = nextGraphemeBoundary(parsed.visible, start, characterIterator);
+            } else {
+                end = findLegalBreak(parsed, start, maxWidth, measurer, lineIterator);
+                if (end < 0) {
+                    end = findGraphemeBreak(parsed, start, maxWidth, measurer, characterIterator);
+                }
+            }
+
+            lines.add(parsed.line(start, end));
+            start = skipSpaces(parsed.visible, end);
+        }
+    }
+
+    private static int findLegalBreak(Paragraph paragraph, int start, int maxWidth,
+                                      WidthMeasurer measurer, BreakIterator iterator) {
+        int best = -1;
+        int boundary = iterator.following(start);
+        while (boundary != BreakIterator.DONE) {
+            int contentEnd = trimSpaces(paragraph.visible, start, boundary);
+            if (contentEnd > start) {
+                if (!fits(paragraph, start, contentEnd, maxWidth, measurer)) {
+                    break;
+                }
+                best = contentEnd;
+            }
+            boundary = iterator.next();
+        }
+        return best;
+    }
+
+    private static int findGraphemeBreak(Paragraph paragraph, int start, int maxWidth,
+                                         WidthMeasurer measurer, BreakIterator iterator) {
+        int best = -1;
+        int cursor = start;
+        int first = nextGraphemeBoundary(paragraph.visible, start, iterator);
+        while (cursor < paragraph.visible.length()) {
+            int next = nextGraphemeBoundary(paragraph.visible, cursor, iterator);
+            if (!fits(paragraph, start, next, maxWidth, measurer)) {
+                break;
+            }
+            best = next;
+            cursor = next;
+        }
+
+        // Even a single grapheme can be wider than the container. Keeping it
+        // intact on its own line guarantees progress without corrupting text.
+        return best < 0 ? first : best;
+    }
+
+    private static boolean fits(Paragraph paragraph, int start, int end, int maxWidth,
+                                WidthMeasurer measurer) {
+        return measurer.width(paragraph.line(start, end)) <= maxWidth;
+    }
+
+    private static int trimSpaces(String text, int start, int end) {
+        while (end > start && text.charAt(end - 1) == ' ') {
+            end--;
+        }
+        return end;
+    }
+
+    private static int skipSpaces(String text, int start) {
+        while (start < text.length() && text.charAt(start) == ' ') {
+            start++;
+        }
+        return start;
+    }
+
+    private static int nextGraphemeBoundary(String text, int start, BreakIterator iterator) {
+        int end = iterator.following(start);
+        if (end == BreakIterator.DONE) {
+            return text.length();
+        }
+        if (end < text.length() && Character.isHighSurrogate(text.charAt(end - 1))
+            && Character.isLowSurrogate(text.charAt(end))) {
+            end++;
+        }
+
+        boolean regionalIndicatorPair = isRegionalIndicator(text.codePointAt(start));
+        int regionalIndicators = regionalIndicatorPair ? countRegionalIndicators(text, start, end) : 0;
+        while (end < text.length()) {
+            int previous = text.codePointBefore(end);
+            int next = text.codePointAt(end);
+            boolean join = isGraphemeExtender(next);
+            if (regionalIndicatorPair && regionalIndicators < 2 && isRegionalIndicator(next)) {
+                join = true;
+                regionalIndicators++;
+            } else if (next == 0x200d) {
+                join = isExtendedPictographic(previous)
+                    && end + 1 < text.length()
+                    && isExtendedPictographic(text.codePointAt(end + 1));
+            } else if (previous == 0x200d) {
+                int beforeZwj = end - 1;
+                int preceding = beforeZwj > 0 ? text.codePointBefore(beforeZwj) : -1;
+                join = isExtendedPictographic(preceding) && isExtendedPictographic(next);
+            }
+            if (!join) {
+                break;
+            }
+
+            int following = iterator.following(end);
+            if (following == BreakIterator.DONE) {
+                return text.length();
+            }
+            end = following;
+            if (end < text.length() && Character.isHighSurrogate(text.charAt(end - 1))
+                && Character.isLowSurrogate(text.charAt(end))) {
+                end++;
+            }
+        }
+        return end;
+    }
+
+    private static boolean isGraphemeExtender(int codePoint) {
+        int type = Character.getType(codePoint);
+        return type == Character.NON_SPACING_MARK
+            || type == Character.COMBINING_SPACING_MARK
+            || type == Character.ENCLOSING_MARK
+            || codePoint >= 0xfe00 && codePoint <= 0xfe0f
+            || codePoint >= 0xe0100 && codePoint <= 0xe01ef
+            || codePoint >= 0x1f3fb && codePoint <= 0x1f3ff
+            || codePoint >= 0xe0020 && codePoint <= 0xe007f;
+    }
+
+    private static boolean isRegionalIndicator(int codePoint) {
+        return codePoint >= 0x1f1e6 && codePoint <= 0x1f1ff;
+    }
+
+    private static int countRegionalIndicators(String text, int start, int end) {
+        int count = 0;
+        for (int index = start; index < end;) {
+            int codePoint = text.codePointAt(index);
+            if (!isRegionalIndicator(codePoint)) {
+                break;
+            }
+            count++;
+            index += Character.charCount(codePoint);
+        }
+        return count;
+    }
+
+    private static boolean isExtendedPictographic(int codePoint) {
+        return codePoint >= 0x1f000 && codePoint <= 0x1faff
+            || codePoint >= 0x2600 && codePoint <= 0x27bf
+            || codePoint == 0x00a9 || codePoint == 0x00ae
+            || codePoint == 0x203c || codePoint == 0x2049
+            || codePoint == 0x2122 || codePoint == 0x2139
+            || codePoint >= 0x2194 && codePoint <= 0x21ff
+            || codePoint >= 0x2300 && codePoint <= 0x23ff
+            || codePoint >= 0x2b00 && codePoint <= 0x2bff
+            || codePoint >= 0x3030 && codePoint <= 0x303d
+            || codePoint >= 0x3297 && codePoint <= 0x3299;
+    }
+
+    private static String normalizeSpaces(String text) {
+        StringBuilder normalized = new StringBuilder(text.length());
+        StringBuilder controlsAfterSpace = new StringBuilder();
+        boolean hasVisibleText = false;
+        boolean pendingSpace = false;
+
+        for (int i = 0; i < text.length();) {
+            if (isFormatCode(text, i)) {
+                if (pendingSpace) {
+                    controlsAfterSpace.append(text, i, i + 2);
+                } else {
+                    normalized.append(text, i, i + 2);
+                }
+                i += 2;
+                continue;
+            }
+
+            char current = text.charAt(i++);
+            if (current == ' ') {
+                if (hasVisibleText) {
+                    pendingSpace = true;
+                }
+                continue;
+            }
+
+            if (pendingSpace) {
+                normalized.append(' ').append(controlsAfterSpace);
+                controlsAfterSpace.setLength(0);
+                pendingSpace = false;
+            }
+            normalized.append(current);
+            hasVisibleText = true;
+        }
+
+        // Formatting after a trimmed trailing space is harmless, but retaining
+        // it keeps the source mapping faithful without retaining the space.
+        normalized.append(controlsAfterSpace);
+        return normalized.toString();
+    }
+
+    private static boolean isFormatCode(String text, int index) {
+        return text.charAt(index) == FORMAT_MARKER && index + 1 < text.length();
+    }
+
+    private static final class Paragraph {
+        private final String formatted;
+        private final String visible;
+        private final int[] rawBoundary;
+
+        private Paragraph(String formatted, String visible, int[] rawBoundary) {
+            this.formatted = formatted;
+            this.visible = visible;
+            this.rawBoundary = rawBoundary;
+        }
+
+        private static Paragraph parse(String formatted) {
+            StringBuilder visible = new StringBuilder(formatted.length());
+            List<Integer> boundaries = new ArrayList<Integer>();
+            int boundaryStart = 0;
+
+            for (int raw = 0; raw < formatted.length();) {
+                if (isFormatCode(formatted, raw)) {
+                    raw += 2;
+                    continue;
+                }
+
+                boundaries.add(boundaryStart);
+                visible.append(formatted.charAt(raw++));
+                boundaryStart = raw;
+            }
+            boundaries.add(boundaryStart);
+
+            int[] rawBoundary = new int[boundaries.size()];
+            for (int i = 0; i < boundaries.size(); i++) {
+                rawBoundary[i] = boundaries.get(i);
+            }
+
+            return new Paragraph(formatted, visible.toString(), rawBoundary);
+        }
+
+        private String line(int visualStart, int visualEnd) {
+            int rawStart = rawBoundary[visualStart];
+            int rawEnd = rawBoundary[visualEnd];
+            String prefix = visualStart == 0 ? "" : formattingAt(rawStart);
+            return prefix + formatted.substring(rawStart, rawEnd);
+        }
+
+        private String formattingAt(int rawEnd) {
+            FormattingState state = new FormattingState();
+            for (int i = 0; i < rawEnd;) {
+                if (isFormatCode(formatted, i)) {
+                    state.apply(formatted.charAt(i + 1));
+                    i += 2;
+                } else {
+                    i++;
+                }
+            }
+            return state.prefix();
+        }
+    }
+
+    private static final class FormattingState {
+        private char color;
+        private boolean obfuscated;
+        private boolean bold;
+        private boolean strikethrough;
+        private boolean underline;
+        private boolean italic;
+
+        private void apply(char code) {
+            code = Character.toLowerCase(code);
+            if ((code >= '0' && code <= '9') || (code >= 'a' && code <= 'f')) {
+                color = code;
+                clearStyles();
+            } else if (code == 'k') {
+                obfuscated = true;
+            } else if (code == 'l') {
+                bold = true;
+            } else if (code == 'm') {
+                strikethrough = true;
+            } else if (code == 'n') {
+                underline = true;
+            } else if (code == 'o') {
+                italic = true;
+            } else if (code == 'r') {
+                color = 0;
+                clearStyles();
+            }
+        }
+
+        private void clearStyles() {
+            obfuscated = false;
+            bold = false;
+            strikethrough = false;
+            underline = false;
+            italic = false;
+        }
+
+        private String prefix() {
+            StringBuilder result = new StringBuilder(12);
+            append(result, color);
+            append(result, obfuscated, 'k');
+            append(result, bold, 'l');
+            append(result, strikethrough, 'm');
+            append(result, underline, 'n');
+            append(result, italic, 'o');
+            return result.toString();
+        }
+
+        private static void append(StringBuilder target, char code) {
+            if (code != 0) {
+                target.append(FORMAT_MARKER).append(code);
+            }
+        }
+
+        private static void append(StringBuilder target, boolean active, char code) {
+            if (active) {
+                target.append(FORMAT_MARKER).append(code);
+            }
+        }
+    }
+}

--- a/src/test/java/noppes/npcs/client/UnicodeLineWrapperTest.java
+++ b/src/test/java/noppes/npcs/client/UnicodeLineWrapperTest.java
@@ -1,0 +1,143 @@
+package noppes.npcs.client;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class UnicodeLineWrapperTest {
+    private static final UnicodeLineWrapper.WidthMeasurer CODE_POINT_WIDTH =
+        new UnicodeLineWrapper.WidthMeasurer() {
+            @Override
+            public int width(String text) {
+                String visible = stripFormatting(text);
+                return visible.codePointCount(0, visible.length());
+            }
+        };
+
+    @Test
+    public void wrapsUnspacedChineseText() {
+        assertLines(Arrays.asList("这是中文", "没有空格"), wrap("这是中文没有空格", 4));
+    }
+
+    @Test
+    public void observesCjkClosingAndOpeningPunctuationRules() {
+        assertLines(Arrays.asList("你", "好，", "世", "界。"), wrap("你好，世界。", 2));
+        assertLines(Arrays.asList("（你", "好）", "世界"), wrap("（你好）世界", 2));
+    }
+
+    @Test
+    public void keepsLatinWordsTogetherInMixedText() {
+        assertLines(Arrays.asList("中文", "English", "混排"), wrap("中文 English 混排", 7));
+    }
+
+    @Test
+    public void splitsAWordOnlyWhenItHasNoFittingLegalBreak() {
+        assertLines(Arrays.asList("abcd", "efgh", "i"), wrap("abcdefghi", 4));
+    }
+
+    @Test
+    public void acceptsAnExactWidthBoundary() {
+        assertLines(Arrays.asList("abcd", "ef"), wrap("abcd ef", 4));
+        assertLines(Arrays.asList("abcd"), wrap("abcd", 4));
+    }
+
+    @Test
+    public void nonPositiveWidthsStillAdvanceOneGraphemeAtATime() {
+        assertLines(Arrays.asList("中", "文"), wrap("中文", 0));
+        assertLines(Arrays.asList("A", "B"), wrap("AB", -1));
+    }
+
+    @Test
+    public void normalizesOrdinarySpacesAndDropsSpacesAtSoftBreaks() {
+        assertLines(Arrays.asList("alpha beta"), wrap("  alpha   beta  ", 100));
+        assertLines(Arrays.asList("alpha", "beta"), wrap("  alpha   beta  ", 5));
+    }
+
+    @Test
+    public void recognizesLfCrAndCrLfAsHardBreaks() {
+        assertLines(Arrays.asList("a", "b", "c", "d"), wrap("a\r\nb\rc\nd", 100));
+    }
+
+    @Test
+    public void preservesConsecutiveHardBreaksButNotAnExtraTrailingLine() {
+        assertLines(Arrays.asList("one", "", "two"), wrap("one\n\ntwo", 100));
+        assertLines(Arrays.asList("one"), wrap("one\n", 100));
+        assertLines(Arrays.asList("one", ""), wrap("one\n\n", 100));
+        assertLines(Arrays.asList(""), wrap("\n", 100));
+    }
+
+    @Test
+    public void continuesColorAndStyleAcrossSoftBreaks() {
+        assertLines(Arrays.asList("§a§lAB", "§a§lCD"), wrap("§a§lABCD", 2));
+        assertLines(Arrays.asList("§aA", "§a§bB", "§bC"), wrap("§aA§bBC", 1));
+        assertLines(Arrays.asList("§lA", "§lB", "§l§rC"), wrap("§lAB§rC", 1));
+    }
+
+    @Test
+    public void doesNotContinueFormattingAcrossHardBreaks() {
+        assertLines(Arrays.asList("§aA", "B"), wrap("§aA\nB", 100));
+    }
+
+    @Test
+    public void formattingCodesAreZeroWidthAndDoNotCreateFakeLines() {
+        assertLines(Arrays.asList("§aAB"), wrap("§aAB", 2));
+        assertLines(Arrays.<String>asList(), wrap("§a", 2));
+        assertLines(Arrays.asList(""), wrap("§a\n§b", 2));
+
+        for (String line : wrap("§a§lABCD", 1)) {
+            assertFalse("format-only line: " + line, stripFormatting(line).isEmpty());
+        }
+    }
+
+    @Test
+    public void doesNotSplitCombiningCharacters() {
+        assertLines(Arrays.asList("e\u0301", "x"), wrap("e\u0301x", 1));
+    }
+
+    @Test
+    public void doesNotSplitSurrogatePairs() {
+        assertLines(Arrays.asList("😀", "x"), wrap("😀x", 1));
+    }
+
+    @Test
+    public void doesNotSplitEmojiModifiersOrVariationSelectors() {
+        assertLines(Arrays.asList("👍🏽", "x"), wrap("👍🏽x", 1));
+        assertLines(Arrays.asList("❤️", "x"), wrap("❤️x", 1));
+    }
+
+    @Test
+    public void doesNotSplitZwjEmojiSequences() {
+        String family = "👨‍👩‍👧‍👦";
+        assertLines(Arrays.asList(family, "x"), wrap(family + "x", 1));
+    }
+
+    @Test
+    public void pairsRegionalIndicatorsAndDoesNotOverJoinPlainZwjText() {
+        assertLines(Arrays.asList("🇦🇧", "🇨"), wrap("🇦🇧🇨", 1));
+        assertLines(Arrays.asList("a", "‍", "b"), wrap("a‍b", 1));
+    }
+
+    private static List<String> wrap(String text, int maxWidth) {
+        return UnicodeLineWrapper.wrap(text, maxWidth, CODE_POINT_WIDTH);
+    }
+
+    private static void assertLines(List<String> expected, List<String> actual) {
+        assertEquals(expected, actual);
+    }
+
+    private static String stripFormatting(String text) {
+        StringBuilder visible = new StringBuilder(text.length());
+        for (int i = 0; i < text.length();) {
+            if (text.charAt(i) == '§' && i + 1 < text.length()) {
+                i += 2;
+            } else {
+                visible.append(text.charAt(i++));
+            }
+        }
+        return visible.toString();
+    }
+}


### PR DESCRIPTION
- Add a Unicode-aware line wrapper based on `BreakIterator`.
- Support CJK text, mixed Chinese/English content, punctuation rules, long words, emoji, combining characters,surrogate pairs, and ZWJ sequences.
- Preserve Minecraft `§` formatting codes across soft-wrapped lines.
- Keep existing whitespace and hard-break behavior compatible.
- Reuse Minecraft and custom font width measurements through `TextBlockClient`.
- Add JUnit 4 coverage for Unicode, whitespace, formatting, emoji, and edge cases.